### PR TITLE
feat(automated-checks): Fix visualizationType vs test key bug

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
@@ -46,6 +47,7 @@ export type DetailsViewContentDeps = {
     isResultHighlightUnavailable: IsResultHighlightUnavailable;
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     testViewContainerProvider: TestViewContainerProvider;
+    getProvider: () => AssessmentsProvider;
 } & InteractiveHeaderDeps &
     DetailsViewOverlayDeps &
     DetailsViewBodyDeps;
@@ -145,16 +147,19 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 props.storeState,
             );
 
+        const selectedTestKey = props.deps.getProvider().forType(selectedTest)?.key;
+
         const assessmentCardsViewData = props.deps.getCardViewData(
             assessmentStoreData,
             props.deps.getCardSelectionViewData(
                 assessmentCardSelectionStoreData
-                    ? assessmentCardSelectionStoreData[selectedTest]
+                    ? assessmentCardSelectionStoreData[selectedTestKey]
                     : null,
-                convertStoreDataForScanNodeResults(assessmentStoreData),
+                convertStoreDataForScanNodeResults(assessmentStoreData, null, selectedTestKey),
                 null,
                 props.deps.isResultHighlightUnavailable,
             ),
+            selectedTestKey,
         );
 
         const targetAppInfo = {

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -8,7 +8,10 @@ import { InspectActionMessageCreator } from 'common/message-creators/inspect-act
 import { ScopingActionMessageCreator } from 'common/message-creators/scoping-action-message-creator';
 import { NamedFC } from 'common/react/named-fc';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
-import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
+import {
+    convertAssessmentStoreDataToScanNodeResults,
+    convertUnifiedStoreDataToScanNodeResults,
+} from 'common/store-data-to-scan-node-result-converter';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import {
     DetailsViewOverlay,
@@ -112,7 +115,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
         const selectedTest =
             selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(storeState);
 
-        const unifiedScanNodeResults = convertStoreDataForScanNodeResults(
+        const unifiedScanNodeResults = convertUnifiedStoreDataToScanNodeResults(
             props.storeState.unifiedScanResultStoreData,
         );
         const automatedChecksCardsViewData = props.deps.getCardViewData(
@@ -150,18 +153,17 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
 
         const selectedTestKey =
             props.deps.visualizationConfigurationFactory.getConfiguration(selectedTest).key;
+        const selectedCardSelectionStoreData = assessmentCardSelectionStoreData[selectedTestKey];
 
-        const assessmentScanNodeResults = convertStoreDataForScanNodeResults(
+        const assessmentScanNodeResults = convertAssessmentStoreDataToScanNodeResults(
             assessmentStoreData,
-            null,
             selectedTestKey,
+            selectedCardSelectionStoreData,
         );
         const assessmentCardsViewData = props.deps.getCardViewData(
             assessmentScanNodeResults,
             props.deps.getCardSelectionViewData(
-                assessmentCardSelectionStoreData
-                    ? assessmentCardSelectionStoreData[selectedTestKey]
-                    : null,
+                selectedCardSelectionStoreData,
                 assessmentScanNodeResults,
                 null,
                 props.deps.isResultHighlightUnavailable,

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
@@ -47,7 +46,6 @@ export type DetailsViewContentDeps = {
     isResultHighlightUnavailable: IsResultHighlightUnavailable;
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     testViewContainerProvider: TestViewContainerProvider;
-    getProvider: () => AssessmentsProvider;
 } & InteractiveHeaderDeps &
     DetailsViewOverlayDeps &
     DetailsViewBodyDeps;
@@ -114,8 +112,11 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
         const selectedTest =
             selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(storeState);
 
-        const automatedChecksCardsViewData = props.deps.getCardViewData(
+        const unifiedScanNodeResults = convertStoreDataForScanNodeResults(
             props.storeState.unifiedScanResultStoreData,
+        );
+        const automatedChecksCardsViewData = props.deps.getCardViewData(
+            unifiedScanNodeResults,
             props.deps.getCardSelectionViewData(
                 props.storeState.cardSelectionStoreData,
                 props.storeState.unifiedScanResultStoreData.results,
@@ -128,7 +129,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             props.storeState.visualizationScanResultStoreData.tabStops.requirements;
 
         const needsReviewCardsViewData = props.deps.getCardViewData(
-            props.storeState.needsReviewScanResultStoreData,
+            unifiedScanNodeResults,
             props.deps.getCardSelectionViewData(
                 props.storeState.needsReviewCardSelectionStoreData,
                 props.storeState.needsReviewScanResultStoreData.results,
@@ -147,19 +148,24 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 props.storeState,
             );
 
-        const selectedTestKey = props.deps.getProvider().forType(selectedTest)?.key;
+        const selectedTestKey =
+            props.deps.visualizationConfigurationFactory.getConfiguration(selectedTest).key;
 
-        const assessmentCardsViewData = props.deps.getCardViewData(
+        const assessmentScanNodeResults = convertStoreDataForScanNodeResults(
             assessmentStoreData,
+            null,
+            selectedTestKey,
+        );
+        const assessmentCardsViewData = props.deps.getCardViewData(
+            assessmentScanNodeResults,
             props.deps.getCardSelectionViewData(
                 assessmentCardSelectionStoreData
                     ? assessmentCardSelectionStoreData[selectedTestKey]
                     : null,
-                convertStoreDataForScanNodeResults(assessmentStoreData, null, selectedTestKey),
+                assessmentScanNodeResults,
                 null,
                 props.deps.isResultHighlightUnavailable,
             ),
-            selectedTestKey,
         );
 
         const targetAppInfo = {

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -8,8 +8,8 @@ import { Logger } from 'common/logging/logger';
 import {
     convertResultsToCardSelectionStoreData,
     ConvertResultsToCardSelectionStoreDataCallback,
-    convertStoreDataForScanNodeResults,
-    ConvertStoreDataForScanNodeResultsCallback,
+    convertUnifiedStoreDataToScanNodeResults,
+    ConvertUnifiedStoreDataToScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { forOwn, isEmpty } from 'lodash';
@@ -37,7 +37,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         tabId: number,
         persistStoreData: boolean,
         private readonly convertResultsToCardSelectionStoreDataCallback: ConvertResultsToCardSelectionStoreDataCallback = convertResultsToCardSelectionStoreData,
-        private readonly getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
+        private readonly convertDataToScanNodeResults: ConvertUnifiedStoreDataToScanNodeResultsCallback = convertUnifiedStoreDataToScanNodeResults,
     ) {
         super(
             StoreNames.CardSelectionStore,
@@ -173,7 +173,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
             return;
         }
 
-        const results = this.getStoreDataForScanNodeResults({
+        const results = this.convertDataToScanNodeResults({
             results: payload.scanResult,
         } as UnifiedScanResultStoreData);
         if (results) {

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -8,6 +8,8 @@ import { Logger } from 'common/logging/logger';
 import {
     convertResultsToCardSelectionStoreData,
     ConvertResultsToCardSelectionStoreDataCallback,
+    convertStoreDataForScanNodeResults,
+    ConvertStoreDataForScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { forOwn, isEmpty } from 'lodash';
@@ -35,6 +37,7 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         tabId: number,
         persistStoreData: boolean,
         private readonly convertResultsToCardSelectionStoreDataCallback: ConvertResultsToCardSelectionStoreDataCallback = convertResultsToCardSelectionStoreData,
+        private readonly getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
     ) {
         super(
             StoreNames.CardSelectionStore,
@@ -170,9 +173,12 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
             return;
         }
 
-        this.state = this.convertResultsToCardSelectionStoreDataCallback(this.state, {
+        const results = this.getStoreDataForScanNodeResults({
             results: payload.scanResult,
         } as UnifiedScanResultStoreData);
+        if (results) {
+            this.state = this.convertResultsToCardSelectionStoreDataCallback(this.state, results);
+        }
 
         this.state.visualHelperEnabled = true;
 

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -10,6 +10,8 @@ import { Logger } from 'common/logging/logger';
 import {
     convertResultsToCardSelectionStoreData,
     ConvertResultsToCardSelectionStoreDataCallback,
+    convertStoreDataForScanNodeResults,
+    ConvertStoreDataForScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -33,6 +35,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         tabId: number,
         persistStoreData: boolean,
         private readonly convertResultsToCardSelectionStoreDataCallback: ConvertResultsToCardSelectionStoreDataCallback = convertResultsToCardSelectionStoreData,
+        private readonly getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
     ) {
         super(
             StoreNames.NeedsReviewCardSelectionStore,
@@ -180,9 +183,12 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             return;
         }
 
-        this.state = this.convertResultsToCardSelectionStoreDataCallback(this.state, {
+        const results = this.getStoreDataForScanNodeResults({
             results: payload.scanResult,
         } as UnifiedScanResultStoreData);
+        if (results) {
+            this.state = this.convertResultsToCardSelectionStoreDataCallback(this.state, results);
+        }
 
         this.state.visualHelperEnabled = true;
 

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -10,8 +10,8 @@ import { Logger } from 'common/logging/logger';
 import {
     convertResultsToCardSelectionStoreData,
     ConvertResultsToCardSelectionStoreDataCallback,
-    convertStoreDataForScanNodeResults,
-    ConvertStoreDataForScanNodeResultsCallback,
+    convertUnifiedStoreDataToScanNodeResults,
+    ConvertUnifiedStoreDataToScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -35,7 +35,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         tabId: number,
         persistStoreData: boolean,
         private readonly convertResultsToCardSelectionStoreDataCallback: ConvertResultsToCardSelectionStoreDataCallback = convertResultsToCardSelectionStoreData,
-        private readonly getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
+        private readonly convertDataToScanNodeResults: ConvertUnifiedStoreDataToScanNodeResultsCallback = convertUnifiedStoreDataToScanNodeResults,
     ) {
         super(
             StoreNames.NeedsReviewCardSelectionStore,
@@ -183,7 +183,7 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             return;
         }
 
-        const results = this.getStoreDataForScanNodeResults({
+        const results = this.convertDataToScanNodeResults({
             results: payload.scanResult,
         } as UnifiedScanResultStoreData);
         if (results) {

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -23,15 +23,21 @@ import { UnifiedRule, UnifiedScanResultStoreData } from './types/store-data/unif
 export type GetCardViewData = (
     storeData: UnifiedScanResultStoreData | AssessmentStoreData,
     cardSelectionViewData: CardSelectionViewData,
+    selectedTestKey?: string,
     getStoreDataForScanNodeResults?: ConvertStoreDataForScanNodeResultsCallback,
 ) => CardsViewModel | null;
 
 export const getCardViewData: GetCardViewData = (
     storeData: UnifiedScanResultStoreData | AssessmentStoreData,
     cardSelectionViewData: CardSelectionViewData,
+    selectedTestKey?: string,
     getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
 ): CardsViewModel | null => {
-    const results: ScanNodeResult[] | null = getStoreDataForScanNodeResults(storeData);
+    const results: ScanNodeResult[] | null = getStoreDataForScanNodeResults(
+        storeData,
+        undefined,
+        selectedTestKey,
+    );
     if (results == null || cardSelectionViewData == null) {
         return null;
     }

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
-import {
-    convertStoreDataForScanNodeResults,
-    ConvertStoreDataForScanNodeResultsCallback,
-    ScanNodeResult,
-} from 'common/store-data-to-scan-node-result-converter';
-import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { ScanNodeResult } from 'common/store-data-to-scan-node-result-converter';
 import { includes } from 'lodash';
 
 import {
@@ -18,41 +13,22 @@ import {
     CardsViewModel,
     HighlightState,
 } from './types/store-data/card-view-model';
-import { UnifiedRule, UnifiedScanResultStoreData } from './types/store-data/unified-data-interface';
+import { UnifiedRule } from './types/store-data/unified-data-interface';
 
 export type GetCardViewData = (
-    storeData: UnifiedScanResultStoreData | AssessmentStoreData,
+    results: ScanNodeResult[],
     cardSelectionViewData: CardSelectionViewData,
-    selectedTestKey?: string,
-    getStoreDataForScanNodeResults?: ConvertStoreDataForScanNodeResultsCallback,
+    rules?: UnifiedRule[],
 ) => CardsViewModel | null;
 
 export const getCardViewData: GetCardViewData = (
-    storeData: UnifiedScanResultStoreData | AssessmentStoreData,
-    cardSelectionViewData: CardSelectionViewData,
-    selectedTestKey?: string,
-    getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
-): CardsViewModel | null => {
-    const results: ScanNodeResult[] | null = getStoreDataForScanNodeResults(
-        storeData,
-        undefined,
-        selectedTestKey,
-    );
-    if (results == null || cardSelectionViewData == null) {
-        return null;
-    }
-    return getCardViewDataFromScanNodeResults(
-        results,
-        cardSelectionViewData,
-        'rules' in storeData && storeData.rules ? storeData.rules : undefined,
-    );
-};
-
-const getCardViewDataFromScanNodeResults = (
     results: ScanNodeResult[],
     cardSelectionViewData: CardSelectionViewData,
     rules?: UnifiedRule[],
 ): CardsViewModel | null => {
+    if (results == null || cardSelectionViewData == null) {
+        return null;
+    }
     const statusResults = getEmptyStatusResults();
     const ruleIdsWithResultNodes: Set<string> = new Set();
 

--- a/src/common/store-data-to-scan-node-result-converter.ts
+++ b/src/common/store-data-to-scan-node-result-converter.ts
@@ -26,11 +26,13 @@ export type ScanNodeResult = UnifiedResult & {
 export type ConvertStoreDataForScanNodeResultsCallback = (
     storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
     cardSelectionStoreData?: CardSelectionStoreData,
+    testKey?: string,
 ) => ScanNodeResult[] | null;
 
 export const convertStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = (
     storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
     cardSelectionStoreData?: CardSelectionStoreData,
+    testKey?: string,
 ): ScanNodeResult[] | null => {
     let results: ScanNodeResult[] | null = convertUnifiedStoreDataToScanNodeResults(
         storeData as UnifiedScanResultStoreData,
@@ -38,6 +40,7 @@ export const convertStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResu
     if (results === null) {
         results = convertAssessmentStoreDataToScanNodeResults(
             storeData as AssessmentStoreData,
+            testKey,
             cardSelectionStoreData,
         );
     }
@@ -47,14 +50,16 @@ export const convertStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResu
 export type ConvertResultsToCardSelectionStoreDataCallback = (
     state: CardSelectionStoreData,
     storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
+    testKey?: string,
 ) => CardSelectionStoreData;
 
 export const convertResultsToCardSelectionStoreData: ConvertResultsToCardSelectionStoreDataCallback =
     (
         state: CardSelectionStoreData,
         storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
+        testKey?: string,
     ): CardSelectionStoreData => {
-        const results = convertStoreDataForScanNodeResults(storeData);
+        const results = convertStoreDataForScanNodeResults(storeData, undefined, testKey);
 
         if (results) {
             results.forEach(result => {
@@ -107,22 +112,18 @@ function convertUnifiedStoreDataToScanNodeResults(
 
 function convertAssessmentStoreDataToScanNodeResults(
     assessmentStoreData: AssessmentStoreData | null,
+    selectedTest?: string,
     cardSelectionStoreData?: CardSelectionStoreData,
 ): ScanNodeResult[] | null {
     if (
         isNullOrUndefined(assessmentStoreData) ||
-        isNullOrUndefined(assessmentStoreData.assessmentNavState) ||
         isNullOrUndefined(assessmentStoreData.assessments) ||
-        isNullOrUndefined(
-            assessmentStoreData.assessments[
-                assessmentStoreData.assessmentNavState.selectedTestType
-            ],
-        )
+        isNullOrUndefined(selectedTest) ||
+        isNullOrUndefined(assessmentStoreData.assessments[selectedTest])
     ) {
         return null;
     }
 
-    const selectedTest = assessmentStoreData.assessmentNavState.selectedTestType;
     const testData = assessmentStoreData.assessments[selectedTest];
     const allResults: ScanNodeResult[] = [];
 

--- a/src/common/store-data-to-scan-node-result-converter.ts
+++ b/src/common/store-data-to-scan-node-result-converter.ts
@@ -83,13 +83,13 @@ export function convertUnifiedStoreDataToScanNodeResults(
 export type ConvertAssessmentStoreDataToScanNodeResultsCallback = (
     assessmentStoreData: AssessmentStoreData,
     selectedTest: string,
-    cardSelectionStoreData?: CardSelectionStoreData,
+    cardSelectionStoreData: CardSelectionStoreData,
 ) => ScanNodeResult[] | null;
 
 export function convertAssessmentStoreDataToScanNodeResults(
     assessmentStoreData: AssessmentStoreData,
     selectedTest: string,
-    cardSelectionStoreData?: CardSelectionStoreData,
+    cardSelectionStoreData: CardSelectionStoreData,
 ): ScanNodeResult[] | null {
     if (
         isNullOrUndefined(assessmentStoreData) ||
@@ -130,7 +130,7 @@ function convertAssessmentResultToScanNodeResult(
     selector: string,
     instance: GeneratedAssessmentInstance,
     requirementIdentifier: string,
-    cardSelectionViewDataForTest?: CardSelectionStoreData,
+    cardSelectionViewDataForTest: CardSelectionStoreData,
 ): ScanNodeResult {
     const instanceId = testStepResult.id;
     const status = convertTestStepResultStatusToCardResultStatus(testStepResult.status);

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -4,7 +4,7 @@ import { CardsViewStoreData } from 'common/components/cards/cards-view-store-dat
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
-import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
+import { convertUnifiedStoreDataToScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
@@ -112,7 +112,7 @@ export class ResultsView extends React.Component<ResultsViewProps> {
             contentPageInfo.resultsFilter,
         );
 
-        const unifiedScanNodeResults = convertStoreDataForScanNodeResults(
+        const unifiedScanNodeResults = convertUnifiedStoreDataToScanNodeResults(
             unifiedScanResultStoreData,
         );
         const cardsViewData = deps.getCardsViewData(

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -115,7 +115,11 @@ export class ResultsView extends React.Component<ResultsViewProps> {
         const unifiedScanNodeResults = convertStoreDataForScanNodeResults(
             unifiedScanResultStoreData,
         );
-        const cardsViewData = deps.getCardsViewData(unifiedScanNodeResults, cardSelectionViewData);
+        const cardsViewData = deps.getCardsViewData(
+            unifiedScanNodeResults,
+            cardSelectionViewData,
+            unifiedScanResultStoreData?.rules,
+        );
         deps.toolData = unifiedScanResultStoreData.toolInfo;
 
         const highlightedResultUids = Object.keys(

--- a/src/electron/views/results/results-view.tsx
+++ b/src/electron/views/results/results-view.tsx
@@ -4,6 +4,7 @@ import { CardsViewStoreData } from 'common/components/cards/cards-view-store-dat
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
+import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
@@ -111,10 +112,10 @@ export class ResultsView extends React.Component<ResultsViewProps> {
             contentPageInfo.resultsFilter,
         );
 
-        const cardsViewData = deps.getCardsViewData(
+        const unifiedScanNodeResults = convertStoreDataForScanNodeResults(
             unifiedScanResultStoreData,
-            cardSelectionViewData,
         );
+        const cardsViewData = deps.getCardsViewData(unifiedScanNodeResults, cardSelectionViewData);
         deps.toolData = unifiedScanResultStoreData.toolInfo;
 
         const highlightedResultUids = Object.keys(

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -22,6 +22,7 @@ import { Target } from 'scanner/iruleresults';
 export type GetElementBasedViewModelCallback = (
     storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
     cardSelectionData: CardSelectionStoreData,
+    selectedTestKey?: string,
 ) => SelectorToVisualizationMap | null;
 
 export class ElementBasedViewModelCreator {
@@ -35,10 +36,12 @@ export class ElementBasedViewModelCreator {
     public getElementBasedViewModel: GetElementBasedViewModelCallback = (
         storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
         cardSelectionData: CardSelectionStoreData,
+        selectedTestKey?: string,
     ) => {
         const results: ScanNodeResult[] | null = this.convertStoreDataForScanNodeResults(
             storeData,
             cardSelectionData,
+            selectedTestKey,
         );
 
         if (results == null || cardSelectionData?.rules == null) {

--- a/src/injected/element-based-view-model-creator.ts
+++ b/src/injected/element-based-view-model-creator.ts
@@ -3,26 +3,18 @@
 
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
-import {
-    ConvertStoreDataForScanNodeResultsCallback,
-    ScanNodeResult,
-} from 'common/store-data-to-scan-node-result-converter';
+import { ScanNodeResult } from 'common/store-data-to-scan-node-result-converter';
 import { TargetHelper } from 'common/target-helper';
-import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import {
-    PlatformData,
-    UnifiedResult,
-    UnifiedScanResultStoreData,
-} from 'common/types/store-data/unified-data-interface';
+import { PlatformData, UnifiedResult } from 'common/types/store-data/unified-data-interface';
 import { GetDecoratedAxeNodeCallback } from 'injected/get-decorated-axe-node';
 import { SelectorToVisualizationMap } from 'injected/selector-to-visualization-map';
 import { Target } from 'scanner/iruleresults';
 
 export type GetElementBasedViewModelCallback = (
-    storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
+    storeData: ScanNodeResult[],
     cardSelectionData: CardSelectionStoreData,
-    selectedTestKey?: string,
+    platformInfo?: PlatformData,
 ) => SelectorToVisualizationMap | null;
 
 export class ElementBasedViewModelCreator {
@@ -30,43 +22,22 @@ export class ElementBasedViewModelCreator {
         private getDecoratedAxeNode: GetDecoratedAxeNodeCallback,
         private getHighlightedResultInstanceIds: GetCardSelectionViewData,
         private isResultHighlightUnavailable: IsResultHighlightUnavailable,
-        private convertStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback,
     ) {}
 
     public getElementBasedViewModel: GetElementBasedViewModelCallback = (
-        storeData: UnifiedScanResultStoreData | AssessmentStoreData | null,
+        results: ScanNodeResult[],
         cardSelectionData: CardSelectionStoreData,
-        selectedTestKey?: string,
+        platformInfo?: PlatformData,
     ) => {
-        const results: ScanNodeResult[] | null = this.convertStoreDataForScanNodeResults(
-            storeData,
-            cardSelectionData,
-            selectedTestKey,
-        );
-
         if (results == null || cardSelectionData?.rules == null) {
             return null;
         }
 
-        return this.getSelectorToVisualizationMap(
-            cardSelectionData,
-            results,
-            storeData && 'platformInfo' in storeData && storeData.platformInfo
-                ? storeData.platformInfo
-                : null,
-        );
-    };
-
-    private getSelectorToVisualizationMap(
-        cardSelectionData: CardSelectionStoreData,
-        results: ScanNodeResult[],
-        platformInfo: PlatformData | null,
-    ): SelectorToVisualizationMap {
         const resultDictionary: SelectorToVisualizationMap = {};
         const resultsHighlightStatus = this.getHighlightedResultInstanceIds(
             cardSelectionData,
             results,
-            platformInfo,
+            platformInfo ?? null,
             this.isResultHighlightUnavailable,
         ).resultsHighlightStatus;
 
@@ -93,7 +64,7 @@ export class ElementBasedViewModelCreator {
         });
 
         return resultDictionary;
-    }
+    };
 
     private getTarget(unifiedResult: UnifiedResult): Target {
         return unifiedResult.identifiers.target

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -4,7 +4,6 @@ import { createToolData } from 'common/application-properties-provider';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unavailable';
 import { Logger } from 'common/logging/logger';
-import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
@@ -227,7 +226,6 @@ export class MainWindowInitializer extends WindowInitializer {
             getDecoratedAxeNode,
             getCardSelectionViewData,
             isResultHighlightUnavailableWeb,
-            convertStoreDataForScanNodeResults,
         );
         const selectorMapHelper = new SelectorMapHelper(
             this.visualizationConfigurationFactory,

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -4,8 +4,10 @@ import { AutomatedChecks } from 'assessments/automated-checks/assessment';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlags } from 'common/feature-flags';
 import {
-    convertStoreDataForScanNodeResults,
-    ConvertStoreDataForScanNodeResultsCallback,
+    convertAssessmentStoreDataToScanNodeResults,
+    ConvertAssessmentStoreDataToScanNodeResultsCallback,
+    convertUnifiedStoreDataToScanNodeResults,
+    ConvertUnifiedStoreDataToScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
@@ -39,7 +41,8 @@ export class SelectorMapHelper {
         private visualizationConfigurationFactory: VisualizationConfigurationFactory,
         private getElementBasedViewModel: GetElementBasedViewModelCallback,
         private getVisualizationInstancesForTabStops: typeof GetVisualizationInstancesForTabStops,
-        private readonly getStoreDataForScanNodeResults: ConvertStoreDataForScanNodeResultsCallback = convertStoreDataForScanNodeResults,
+        private readonly convertUnifiedDataToScanNodeResults: ConvertUnifiedStoreDataToScanNodeResultsCallback = convertUnifiedStoreDataToScanNodeResults,
+        private readonly convertAssessmentDataToScanNodeResults: ConvertAssessmentStoreDataToScanNodeResultsCallback = convertAssessmentStoreDataToScanNodeResults,
     ) {}
 
     public getSelectorMap(
@@ -73,10 +76,10 @@ export class SelectorMapHelper {
             this.visualizationConfigurationFactory.getConfiguration(visualizationType);
         if (featureFlagStoreData[FeatureFlags.automatedChecks]) {
             if (assessmentConfig.key === AutomatedChecks.getVisualizationConfiguration().key) {
-                const assessmentScanNodeResults = this.getStoreDataForScanNodeResults(
+                const assessmentScanNodeResults = this.convertAssessmentDataToScanNodeResults(
                     assessmentStoreData,
-                    assessmentCardSelectionStoreData[assessmentConfig.key],
                     assessmentConfig.key,
+                    assessmentCardSelectionStoreData[assessmentConfig.key],
                 );
                 return this.getElementBasedViewModel(
                     assessmentScanNodeResults,
@@ -120,17 +123,14 @@ export class SelectorMapHelper {
         switch (visualizationType) {
             case VisualizationType.NeedsReview:
                 selectorMap = this.getElementBasedViewModel(
-                    this.getStoreDataForScanNodeResults(
-                        needsReviewScanData,
-                        needsReviewCardSelectionStoreData,
-                    ),
+                    this.convertUnifiedDataToScanNodeResults(needsReviewScanData),
                     needsReviewCardSelectionStoreData,
                     needsReviewScanData.platformInfo,
                 );
                 break;
             case VisualizationType.Issues:
                 selectorMap = this.getElementBasedViewModel(
-                    this.getStoreDataForScanNodeResults(unifiedScanData, cardSelectionStoreData),
+                    this.convertUnifiedDataToScanNodeResults(unifiedScanData),
                     cardSelectionStoreData,
                     unifiedScanData.platformInfo,
                 );

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -71,8 +71,9 @@ export class SelectorMapHelper {
                 return this.getElementBasedViewModel(
                     assessmentStoreData,
                     assessmentCardSelectionStoreData
-                        ? assessmentCardSelectionStoreData[visualizationType]
+                        ? assessmentCardSelectionStoreData[assessmentConfig.key]
                         : null,
+                    assessmentConfig.key,
                 );
             }
         }

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
+import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
 import { ConvertScanResultsToUnifiedResultsDelegate } from 'injected/adapters/scan-results-to-unified-results';
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
@@ -52,7 +53,8 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
             resultsHighlightStatus: {},
         };
 
-        const cardsViewModel = getCards({ rules: unifiedRules, results: unifiedResults }, cardSelectionViewData);
+        const scanNodeResults = convertStoreDataForScanNodeResults({ rules: unifiedRules, results: unifiedResults });
+        const cardsViewModel = getCards(scanNodeResults, cardSelectionViewData);
 
         const targetAppInfo = {
             name: pageTitle,

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -54,7 +54,7 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
         };
 
         const scanNodeResults = convertStoreDataForScanNodeResults({ rules: unifiedRules, results: unifiedResults });
-        const cardsViewModel = getCards(scanNodeResults, cardSelectionViewData);
+        const cardsViewModel = getCards(scanNodeResults, cardSelectionViewData, unifiedRules);
 
         const targetAppInfo = {
             name: pageTitle,

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
-import { convertStoreDataForScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
+import { convertUnifiedStoreDataToScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { ScanMetadata, ToolData } from 'common/types/store-data/unified-data-interface';
 import { ConvertScanResultsToUnifiedResultsDelegate } from 'injected/adapters/scan-results-to-unified-results';
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
@@ -53,7 +53,7 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
             resultsHighlightStatus: {},
         };
 
-        const scanNodeResults = convertStoreDataForScanNodeResults({ rules: unifiedRules, results: unifiedResults });
+        const scanNodeResults = convertUnifiedStoreDataToScanNodeResults({ rules: unifiedRules, results: unifiedResults });
         const cardsViewModel = getCards(scanNodeResults, cardSelectionViewData, unifiedRules);
 
         const targetAppInfo = {

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -32,13 +32,14 @@ describe('RuleBasedViewModelProvider', () => {
 
     test('getCardViewData with null results', () => {
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(null))
+            .setup(mock => mock(null, undefined, null))
             .returns(() => null)
             .verifiable(Times.once());
 
         const actualResults: CardsViewModel = getCardViewData(
             null,
             emptyCardSelectionViewData,
+            null,
             convertStoreDataForScanNodeResultsCallbackMock.object,
         );
 
@@ -48,12 +49,13 @@ describe('RuleBasedViewModelProvider', () => {
     test('getCardViewData with null card selection view data', () => {
         const storeData = { rules: [], results: [] };
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(storeData))
+            .setup(mock => mock(storeData, undefined, null))
             .returns(() => [])
             .verifiable(Times.once());
 
         const actualResults: CardsViewModel = getCardViewData(
             storeData,
+            null,
             null,
             convertStoreDataForScanNodeResultsCallbackMock.object,
         );
@@ -85,7 +87,7 @@ describe('RuleBasedViewModelProvider', () => {
 
         const storeData = { rules, results };
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(storeData))
+            .setup(mock => mock(storeData, undefined, null))
             .returns(() =>
                 results.map(result => {
                     const rule = rules.find(rule => rule.id === result.ruleId);
@@ -97,6 +99,7 @@ describe('RuleBasedViewModelProvider', () => {
         const actualResults: CardsViewModel = getCardViewData(
             storeData,
             cardSelectionViewData,
+            null,
             convertStoreDataForScanNodeResultsCallbackMock.object,
         );
 

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -13,9 +13,9 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
-        "getProvider": [Function],
         "isResultHighlightUnavailable": [Function],
         "storesHub": [typemoq mock object],
+        "visualizationConfigurationFactory": [typemoq mock object],
       }
     }
     featureFlagStoreData={
@@ -66,9 +66,9 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
-        "getProvider": [Function],
         "isResultHighlightUnavailable": [Function],
         "storesHub": [typemoq mock object],
+        "visualizationConfigurationFactory": [typemoq mock object],
       }
     }
     detailsViewStoreData={
@@ -202,6 +202,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "showSaveAssessmentDialog": true,
       }
     }
+    visualizationConfigurationFactory={[typemoq mock object]}
     visualizationScanResultData={
       {
         "accessibleNames": {
@@ -455,9 +456,9 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
-        "getProvider": [Function],
         "isResultHighlightUnavailable": [Function],
         "storesHub": [typemoq mock object],
+        "visualizationConfigurationFactory": [typemoq mock object],
       }
     }
     detailsViewStoreData={

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
+        "getProvider": [Function],
         "isResultHighlightUnavailable": [Function],
         "storesHub": [typemoq mock object],
       }
@@ -65,6 +66,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
+        "getProvider": [Function],
         "isResultHighlightUnavailable": [Function],
         "storesHub": [typemoq mock object],
       }
@@ -453,6 +455,7 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "getDateFromTimestamp": [Function],
         "getDetailsRightPanelConfiguration": [Function],
         "getDetailsSwitcherNavConfiguration": [Function],
+        "getProvider": [Function],
         "isResultHighlightUnavailable": [Function],
         "storesHub": [typemoq mock object],
       }

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { Assessment } from 'assessments/types/iassessment';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { WebVisualizationConfigurationFactory } from 'common/configs/web-visualization-configuration-factory';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import {
     CardSelectionViewData,
@@ -9,6 +10,7 @@ import {
 } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
+import { ScanNodeResult } from 'common/store-data-to-scan-node-result-converter';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
@@ -58,6 +60,7 @@ describe(DetailsViewContent.displayName, () => {
     let deps: DetailsViewContainerDeps;
     let getDetailsRightPanelConfiguration: IMock<GetDetailsRightPanelConfiguration>;
     let getDetailsSwitcherNavConfiguration: IMock<GetDetailsSwitcherNavConfiguration>;
+    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     let getCardViewDataMock: IMock<GetCardViewData>;
     let getCardSelectionViewDataMock: IMock<GetCardSelectionViewData>;
     let targetAppInfo: TargetAppData;
@@ -66,8 +69,6 @@ describe(DetailsViewContent.displayName, () => {
     let scanDate: Date;
     let toolData: ToolData;
     let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
-    let assessmentsProviderMock: IMock<AssessmentsProvider>;
-    let getProviderMock: IMock<() => AssessmentsProvider>;
 
     beforeEach(() => {
         detailsViewActionMessageCreator = Mock.ofType(DetailsViewActionMessageCreator);
@@ -80,14 +81,16 @@ describe(DetailsViewContent.displayName, () => {
             MockBehavior.Strict,
         );
         getCardViewDataMock = Mock.ofInstance(
-            (
-                storeData: UnifiedScanResultStoreData,
-                cardSelectionViewData?: CardSelectionViewData,
-            ) => null,
+            (scanNodeResults: ScanNodeResult[], cardSelectionViewData?: CardSelectionViewData) =>
+                null,
             MockBehavior.Strict,
         );
         getCardSelectionViewDataMock = Mock.ofInstance(
             (storeData: CardSelectionStoreData) => null,
+            MockBehavior.Strict,
+        );
+        visualizationConfigurationFactoryMock = Mock.ofType(
+            WebVisualizationConfigurationFactory,
             MockBehavior.Strict,
         );
         isResultHighlightUnavailableStub = () => null;
@@ -104,12 +107,6 @@ describe(DetailsViewContent.displayName, () => {
         } as ToolData;
 
         const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
-        assessmentsProviderMock = Mock.ofType<AssessmentsProvider>();
-        getProviderMock = Mock.ofInstance(
-            () => assessmentsProviderMock.object,
-            MockBehavior.Strict,
-        );
-        getProviderMock.setup(g => g()).returns(() => assessmentsProviderMock.object);
 
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
@@ -120,7 +117,7 @@ describe(DetailsViewContent.displayName, () => {
             isResultHighlightUnavailable: isResultHighlightUnavailableStub,
             getDateFromTimestamp: getDateFromTimestampMock.object,
             getAssessmentInstanceTableHandler: () => assessmentInstanceTableHandlerMock.object,
-            getProvider: getProviderMock.object,
+            visualizationConfigurationFactory: visualizationConfigurationFactoryMock.object,
         } as DetailsViewContainerDeps;
     });
 
@@ -217,11 +214,6 @@ describe(DetailsViewContent.displayName, () => {
 
             const state = getState(storeMocks, viewType, rightContentPanelConfig);
 
-            const assessmentStub = { key: 'test-key' } as Assessment;
-            assessmentsProviderMock
-                .setup(apm => apm.forType(viewType))
-                .returns(() => assessmentStub);
-
             getSelectedDetailsViewMock
                 .setup(gsdvm =>
                     gsdvm(
@@ -280,13 +272,18 @@ describe(DetailsViewContent.displayName, () => {
                 .returns(() => cardSelectionViewData)
                 .verifiable(Times.exactly(1));
 
+            const configStub = { key: 'test-key' } as VisualizationConfiguration;
+            visualizationConfigurationFactoryMock
+                .setup(vcfm => vcfm.getConfiguration(viewType))
+                .returns(() => configStub);
+
             const cardsViewData: CardsViewModel = {} as any;
             getCardViewDataMock
-                .setup(m => m(state.unifiedScanResultStoreData, cardSelectionViewData))
+                .setup(m => m([], cardSelectionViewData))
                 .returns(() => cardsViewData);
 
             getCardViewDataMock
-                .setup(m => m(state.assessmentStoreData, cardSelectionViewData, assessmentStub.key))
+                .setup(m => m(null, cardSelectionViewData))
                 .returns(() => cardsViewData);
 
             const rendered = shallow(

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabActions } from 'background/actions/tab-actions';
-import { ConvertResultsToCardSelectionStoreDataCallback } from 'common/store-data-to-scan-node-result-converter';
+import {
+    ConvertResultsToCardSelectionStoreDataCallback,
+    ConvertStoreDataForScanNodeResultsCallback,
+} from 'common/store-data-to-scan-node-result-converter';
 import { cloneDeep, forOwn } from 'lodash';
 import { IMock, Mock, Times } from 'typemoq';
 
@@ -27,10 +30,13 @@ import { createStoreWithNullParams, StoreTester } from '../../../common/store-te
 
 describe('CardSelectionStore Test', () => {
     let convertResultsToCardSelectionStoreDataCallbackMock: IMock<ConvertResultsToCardSelectionStoreDataCallback>;
+    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertStoreDataForScanNodeResultsCallback>;
 
     beforeEach(() => {
         convertResultsToCardSelectionStoreDataCallbackMock =
             Mock.ofType<ConvertResultsToCardSelectionStoreDataCallback>();
+        convertStoreDataForScanNodeResultsCallbackMock =
+            Mock.ofType<ConvertStoreDataForScanNodeResultsCallback>();
     });
 
     test('constructor has no side effects', () => {
@@ -92,12 +98,17 @@ describe('CardSelectionStore Test', () => {
             visualHelperEnabled: false,
             focusedResultUid: null,
         } as CardSelectionStoreData;
-        convertResultsToCardSelectionStoreDataCallbackMock
+        const scanResultsNodesStub = [];
+        convertStoreDataForScanNodeResultsCallbackMock
             .setup(callback =>
-                callback(callbackExpectedState, {
+                callback({
                     results: payload.scanResult,
                 } as UnifiedScanResultStoreData),
             )
+            .returns(() => scanResultsNodesStub)
+            .verifiable(Times.once());
+        convertResultsToCardSelectionStoreDataCallbackMock
+            .setup(callback => callback(callbackExpectedState, scanResultsNodesStub))
             .returns(() => {
                 return expectedState;
             })
@@ -107,6 +118,7 @@ describe('CardSelectionStore Test', () => {
             createStoreForUnifiedScanResultActions('scanCompleted').withActionParam(payload);
         await storeTester.testListenerToBeCalledOnce(initialState, expectedState);
         convertResultsToCardSelectionStoreDataCallbackMock.verifyAll();
+        convertStoreDataForScanNodeResultsCallbackMock.verifyAll();
     });
 
     function getDefaultState(): CardSelectionStoreData {
@@ -127,6 +139,7 @@ describe('CardSelectionStore Test', () => {
                 null,
                 true,
                 convertResultsToCardSelectionStoreDataCallbackMock.object,
+                convertStoreDataForScanNodeResultsCallbackMock.object,
             );
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -3,7 +3,7 @@
 import { TabActions } from 'background/actions/tab-actions';
 import {
     ConvertResultsToCardSelectionStoreDataCallback,
-    ConvertStoreDataForScanNodeResultsCallback,
+    ConvertUnifiedStoreDataToScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { cloneDeep, forOwn } from 'lodash';
 import { IMock, Mock, Times } from 'typemoq';
@@ -30,13 +30,13 @@ import { createStoreWithNullParams, StoreTester } from '../../../common/store-te
 
 describe('CardSelectionStore Test', () => {
     let convertResultsToCardSelectionStoreDataCallbackMock: IMock<ConvertResultsToCardSelectionStoreDataCallback>;
-    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertStoreDataForScanNodeResultsCallback>;
+    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertUnifiedStoreDataToScanNodeResultsCallback>;
 
     beforeEach(() => {
         convertResultsToCardSelectionStoreDataCallbackMock =
             Mock.ofType<ConvertResultsToCardSelectionStoreDataCallback>();
         convertStoreDataForScanNodeResultsCallbackMock =
-            Mock.ofType<ConvertStoreDataForScanNodeResultsCallback>();
+            Mock.ofType<ConvertUnifiedStoreDataToScanNodeResultsCallback>();
     });
 
     test('constructor has no side effects', () => {

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -6,7 +6,7 @@ import { TabActions } from 'background/actions/tab-actions';
 import { NeedsReviewCardSelectionStore } from 'background/stores/needs-review-card-selection-store';
 import {
     ConvertResultsToCardSelectionStoreDataCallback,
-    ConvertStoreDataForScanNodeResultsCallback,
+    ConvertUnifiedStoreDataToScanNodeResultsCallback,
 } from 'common/store-data-to-scan-node-result-converter';
 import { RuleExpandCollapseData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
@@ -28,13 +28,13 @@ import { createStoreWithNullParams, StoreTester } from '../../../common/store-te
 
 describe('NeedsReviewCardSelectionStore Test', () => {
     let convertResultsToCardSelectionStoreDataCallbackMock: IMock<ConvertResultsToCardSelectionStoreDataCallback>;
-    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertStoreDataForScanNodeResultsCallback>;
+    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertUnifiedStoreDataToScanNodeResultsCallback>;
 
     beforeEach(() => {
         convertResultsToCardSelectionStoreDataCallbackMock =
             Mock.ofType<ConvertResultsToCardSelectionStoreDataCallback>();
         convertStoreDataForScanNodeResultsCallbackMock =
-            Mock.ofType<ConvertStoreDataForScanNodeResultsCallback>();
+            Mock.ofType<ConvertUnifiedStoreDataToScanNodeResultsCallback>();
     });
 
     test('constructor has no side effects', () => {

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -91,6 +91,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
         });
 
         test('assessment data with no card selection store data is converted successfully', () => {
+            const testKey = 'test-key';
             const assessmentResult = exampleAssessmentResult;
             const { selector, testStepResult, ruleId } =
                 getAssessmentDataProperties(assessmentResult);
@@ -113,10 +114,13 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+            expect(convertStoreDataForScanNodeResults(storeData, null, testKey)).toEqual(
+                expectedResult,
+            );
         });
 
         test('assessment data with card selection store data is converted successfully', () => {
+            const testKey = 'test-key';
             const assessmentResult = exampleAssessmentResult;
             const { selector, testStepResult, ruleId } =
                 getAssessmentDataProperties(assessmentResult);
@@ -142,12 +146,13 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData, cardSelectionStoreData)).toEqual(
-                expectedResult,
-            );
+            expect(
+                convertStoreDataForScanNodeResults(storeData, cardSelectionStoreData, testKey),
+            ).toEqual(expectedResult);
         });
 
         test('assessment data with multiple failures on one element is converted successfully', () => {
+            const testKey = 'test-key';
             const assessmentResult = cloneDeep(exampleAssessmentResult);
             const {
                 selector,
@@ -164,9 +169,8 @@ describe('StoreDataToScanNodeResultConverter', () => {
 
             const storeData = {
                 assessments: {
-                    'test-key': assessmentResult,
+                    [testKey]: assessmentResult,
                 },
-                assessmentNavState: { selectedTestType: 'test-key' },
             } as unknown as AssessmentStoreData;
 
             const expectedResult = [
@@ -191,10 +195,13 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult2.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+            expect(convertStoreDataForScanNodeResults(storeData, null, testKey)).toEqual(
+                expectedResult,
+            );
         });
 
         test('assessment data with failures on different elements is converted successfully', () => {
+            const testKey = 'test-key';
             const assessmentResult = cloneDeep(exampleAssessmentResult);
             const {
                 testStepResult: testStepResult1,
@@ -217,9 +224,8 @@ describe('StoreDataToScanNodeResultConverter', () => {
 
             const storeData = {
                 assessments: {
-                    'test-key': assessmentResult,
+                    [testKey]: assessmentResult,
                 },
-                assessmentNavState: { selectedTestType: 'test-key' },
             } as unknown as AssessmentStoreData;
 
             const expectedResult = [
@@ -244,7 +250,9 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult2.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+            expect(convertStoreDataForScanNodeResults(storeData, null, testKey)).toEqual(
+                expectedResult,
+            );
         });
 
         function getAssessmentDataProperties(data: AssessmentData) {
@@ -292,15 +300,15 @@ describe('StoreDataToScanNodeResultConverter', () => {
         });
 
         test('assessment data is converted successfully', () => {
+            const testKey = 'test-key';
             const assessmentResult = exampleAssessmentResult;
             const storeData = {
                 assessments: {
-                    'test-key': assessmentResult,
+                    [testKey]: assessmentResult,
                 },
-                assessmentNavState: { selectedTestType: 'test-key' },
             } as unknown as AssessmentStoreData;
 
-            expect(convertResultsToCardSelectionStoreData(stateStub, storeData)).toEqual(
+            expect(convertResultsToCardSelectionStoreData(stateStub, storeData, testKey)).toEqual(
                 expectedResultStub,
             );
         });

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 import {
+    convertAssessmentStoreDataToScanNodeResults,
     convertResultsToCardSelectionStoreData,
-    convertStoreDataForScanNodeResults,
+    convertUnifiedStoreDataToScanNodeResults,
     ScanNodeResult,
 } from 'common/store-data-to-scan-node-result-converter';
 import {
@@ -24,10 +25,10 @@ import {
 } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
 
 describe('StoreDataToScanNodeResultConverter', () => {
-    describe('convertStoreDataForScanNodeResults', () => {
+    describe('convertUnifiedStoreDataToScanNodeResults', () => {
         test('store data is empty returns null', () => {
             const dataStub = {} as UnifiedScanResultStoreData;
-            expect(convertStoreDataForScanNodeResults(dataStub)).toBeNull();
+            expect(convertUnifiedStoreDataToScanNodeResults(dataStub)).toBeNull();
         });
 
         test('unified data with no results returns null', () => {
@@ -35,7 +36,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                 results: [],
                 rules: [],
             } as UnifiedScanResultStoreData;
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual([]);
+            expect(convertUnifiedStoreDataToScanNodeResults(storeData)).toEqual([]);
         });
 
         test('unified data is converted successfully', () => {
@@ -47,7 +48,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
             } as UnifiedScanResultStoreData;
 
             const expectedResult = [{ ...unifiedResult, rule: ruleStub }];
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+            expect(convertUnifiedStoreDataToScanNodeResults(storeData)).toEqual(expectedResult);
         });
 
         test('unified data with no rules is converted successfully', () => {
@@ -57,7 +58,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
             } as UnifiedScanResultStoreData;
 
             const expectedResult = [{ ...unifiedResult, rule: { id: unifiedResult.ruleId } }];
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+            expect(convertUnifiedStoreDataToScanNodeResults(storeData)).toEqual(expectedResult);
         });
 
         test('unified data with multiple results is converted successfully', () => {
@@ -80,15 +81,18 @@ describe('StoreDataToScanNodeResultConverter', () => {
                 { ...unifiedResultOne, rule: ruleStubOne },
                 { ...unifiedResultTwo, rule: ruleStubTwo },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData)).toEqual(expectedResult);
+            expect(convertUnifiedStoreDataToScanNodeResults(storeData)).toEqual(expectedResult);
         });
+    });
 
+    describe('convertAssessmentStoreDataToScanNodeResults', () => {
         test('assessment data with invalid selected test type returns null', () => {
+            const testKey = 'test-key';
             const dataStub = {
                 assessments: {},
-                assessmentNavState: { selectedTestType: 'test-key' },
+                assessmentNavState: { selectedTestType: testKey },
             } as unknown as AssessmentStoreData;
-            expect(convertStoreDataForScanNodeResults(dataStub)).toBeNull();
+            expect(convertAssessmentStoreDataToScanNodeResults(dataStub, testKey)).toBeNull();
         });
 
         test('assessment data with no card selection store data is converted successfully', () => {
@@ -115,7 +119,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData, null, testKey)).toEqual(
+            expect(convertAssessmentStoreDataToScanNodeResults(storeData, testKey, null)).toEqual(
                 expectedResult,
             );
         });
@@ -148,7 +152,11 @@ describe('StoreDataToScanNodeResultConverter', () => {
                 },
             ];
             expect(
-                convertStoreDataForScanNodeResults(storeData, cardSelectionStoreData, testKey),
+                convertAssessmentStoreDataToScanNodeResults(
+                    storeData,
+                    testKey,
+                    cardSelectionStoreData,
+                ),
             ).toEqual(expectedResult);
         });
 
@@ -196,7 +204,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult2.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData, null, testKey)).toEqual(
+            expect(convertAssessmentStoreDataToScanNodeResults(storeData, testKey, null)).toEqual(
                 expectedResult,
             );
         });
@@ -251,7 +259,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                     uid: testStepResult2.id,
                 },
             ];
-            expect(convertStoreDataForScanNodeResults(storeData, null, testKey)).toEqual(
+            expect(convertAssessmentStoreDataToScanNodeResults(storeData, testKey, null)).toEqual(
                 expectedResult,
             );
         });

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -4,6 +4,7 @@
 import {
     convertResultsToCardSelectionStoreData,
     convertStoreDataForScanNodeResults,
+    ScanNodeResult,
 } from 'common/store-data-to-scan-node-result-converter';
 import {
     AssessmentData,
@@ -289,26 +290,9 @@ describe('StoreDataToScanNodeResultConverter', () => {
         test('unified data is converted successfully', () => {
             const unifiedResult = exampleUnifiedResult;
             const ruleStub = { id: unifiedResult.ruleId } as UnifiedRule;
-            const storeData = {
-                results: [unifiedResult],
-                rules: [ruleStub],
-            } as UnifiedScanResultStoreData;
+            const result = { ...unifiedResult, rule: ruleStub } as ScanNodeResult;
 
-            expect(convertResultsToCardSelectionStoreData(stateStub, storeData)).toEqual(
-                expectedResultStub,
-            );
-        });
-
-        test('assessment data is converted successfully', () => {
-            const testKey = 'test-key';
-            const assessmentResult = exampleAssessmentResult;
-            const storeData = {
-                assessments: {
-                    [testKey]: assessmentResult,
-                },
-            } as unknown as AssessmentStoreData;
-
-            expect(convertResultsToCardSelectionStoreData(stateStub, storeData, testKey)).toEqual(
+            expect(convertResultsToCardSelectionStoreData(stateStub, [result])).toEqual(
                 expectedResultStub,
             );
         });

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -92,7 +92,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                 assessments: {},
                 assessmentNavState: { selectedTestType: testKey },
             } as unknown as AssessmentStoreData;
-            expect(convertAssessmentStoreDataToScanNodeResults(dataStub, testKey)).toBeNull();
+            expect(convertAssessmentStoreDataToScanNodeResults(dataStub, testKey, null)).toBeNull();
         });
 
         test('assessment data with no card selection store data is converted successfully', () => {

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -161,7 +161,9 @@ describe('ResultsView', () => {
             .verifiable(Times.once());
 
         getUnifiedRuleResultsMock
-            .setup(getter => getter(It.isAny(), cardSelectionViewDataStub))
+            .setup(getter =>
+                getter(It.isAny(), cardSelectionViewDataStub, unifiedScanResultStoreData.rules),
+            )
             .returns(() => cardsViewData)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/electron/views/results/results-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/results/results-view.test.tsx
@@ -38,7 +38,7 @@ import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-m
 import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('ResultsView', () => {
     const initialSelectedKey: LeftNavItemKey = 'automated-checks';
@@ -161,7 +161,7 @@ describe('ResultsView', () => {
             .verifiable(Times.once());
 
         getUnifiedRuleResultsMock
-            .setup(getter => getter(unifiedScanResultStoreData, cardSelectionViewDataStub))
+            .setup(getter => getter(It.isAny(), cardSelectionViewDataStub))
             .returns(() => cardsViewData)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -5,26 +5,19 @@ import {
     GetCardSelectionViewData,
 } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
-import {
-    ConvertStoreDataForScanNodeResultsCallback,
-    ScanNodeResult,
-} from 'common/store-data-to-scan-node-result-converter';
+import { ScanNodeResult } from 'common/store-data-to-scan-node-result-converter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import {
-    UnifiedRule,
-    UnifiedScanResultStoreData,
-} from 'common/types/store-data/unified-data-interface';
+import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { DecoratedAxeNodeResult } from 'common/types/store-data/visualization-scan-result-data';
 import { ElementBasedViewModelCreator } from 'injected/element-based-view-model-creator';
 import { GetDecoratedAxeNodeCallback } from 'injected/get-decorated-axe-node';
 import { cloneDeep } from 'lodash';
 import { exampleUnifiedResult } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('ElementBasedViewModelCreator', () => {
     let getDecoratedAxeNodeCallbackMock: IMock<GetDecoratedAxeNodeCallback>;
     let getHighlightedResultInstanceIdsMock: IMock<GetCardSelectionViewData>;
-    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertStoreDataForScanNodeResultsCallback>;
     let testSubject: ElementBasedViewModelCreator;
     let cardSelectionData: CardSelectionStoreData;
     let isResultHighlightUnavailableStub: IsResultHighlightUnavailable;
@@ -38,53 +31,34 @@ describe('ElementBasedViewModelCreator', () => {
             undefined,
             MockBehavior.Strict,
         );
-        convertStoreDataForScanNodeResultsCallbackMock =
-            Mock.ofType<ConvertStoreDataForScanNodeResultsCallback>(undefined, MockBehavior.Strict);
         isResultHighlightUnavailableStub = () => null;
         testSubject = new ElementBasedViewModelCreator(
             getDecoratedAxeNodeCallbackMock.object,
             getHighlightedResultInstanceIdsMock.object,
             isResultHighlightUnavailableStub,
-            convertStoreDataForScanNodeResultsCallbackMock.object,
         );
 
         cardSelectionData = { rules: {} } as CardSelectionStoreData;
     });
 
-    afterEach(() => {
-        convertStoreDataForScanNodeResultsCallbackMock.verifyAll();
-    });
-
     test('getElementBasedViewModel: results are null', () => {
-        const dataStub = {} as UnifiedScanResultStoreData;
         const cardSelectionDataStub = {} as CardSelectionStoreData;
-        convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionDataStub, undefined))
-            .returns(() => null)
-            .verifiable(Times.once());
-        expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionDataStub)).toBeNull();
+        expect(testSubject.getElementBasedViewModel(null, cardSelectionDataStub)).toBeNull();
     });
 
     test('getElementBasedViewModel: cardSelectionData are null', () => {
-        const dataStub = {} as UnifiedScanResultStoreData;
+        const dataStub = [];
         const cardSelectionDataStub = null;
-        convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionDataStub, undefined))
-            .returns(() => [])
-            .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionDataStub)).toBeNull();
     });
 
     test('getElementBasedViewModel: cardSelectionData.rules are null', () => {
-        const dataStub = {} as UnifiedScanResultStoreData;
+        const dataStub = [];
         const cardSelectionDataStub = {
             rules: null,
             visualHelperEnabled: true,
             focusedResultUid: null,
         };
-        convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionDataStub, undefined))
-            .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionDataStub)).toBeNull();
     });
 
@@ -114,12 +88,7 @@ describe('ElementBasedViewModelCreator', () => {
 
         const expectedResult = {};
 
-        const dataStub = {} as UnifiedScanResultStoreData;
-        convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionData, undefined))
-            .returns(() => scanNodeResults)
-            .verifiable(Times.once());
-        expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
+        expect(testSubject.getElementBasedViewModel(scanNodeResults, cardSelectionData)).toEqual(
             expectedResult,
         );
     });
@@ -172,14 +141,9 @@ describe('ElementBasedViewModelCreator', () => {
                 },
             };
 
-            const dataStub = {} as UnifiedScanResultStoreData;
-            convertStoreDataForScanNodeResultsCallbackMock
-                .setup(mock => mock(dataStub, cardSelectionData, undefined))
-                .returns(() => scanNodeResults)
-                .verifiable(Times.once());
-            expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
-                expectedResult,
-            );
+            expect(
+                testSubject.getElementBasedViewModel(scanNodeResults, cardSelectionData),
+            ).toEqual(expectedResult);
         },
     );
 
@@ -255,12 +219,7 @@ describe('ElementBasedViewModelCreator', () => {
             },
         };
 
-        const dataStub = {} as UnifiedScanResultStoreData;
-        convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionData, undefined))
-            .returns(() => scanNodeResults)
-            .verifiable(Times.once());
-        expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
+        expect(testSubject.getElementBasedViewModel(scanNodeResults, cardSelectionData)).toEqual(
             expectedResult,
         );
     });
@@ -308,12 +267,7 @@ describe('ElementBasedViewModelCreator', () => {
             },
         };
 
-        const dataStub = {} as UnifiedScanResultStoreData;
-        convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionData, undefined))
-            .returns(() => scanNodeResults)
-            .verifiable(Times.once());
-        expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
+        expect(testSubject.getElementBasedViewModel(scanNodeResults, cardSelectionData)).toEqual(
             expectedResult,
         );
     });

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -59,7 +59,7 @@ describe('ElementBasedViewModelCreator', () => {
         const dataStub = {} as UnifiedScanResultStoreData;
         const cardSelectionDataStub = {} as CardSelectionStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionDataStub))
+            .setup(mock => mock(dataStub, cardSelectionDataStub, undefined))
             .returns(() => null)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionDataStub)).toBeNull();
@@ -69,7 +69,7 @@ describe('ElementBasedViewModelCreator', () => {
         const dataStub = {} as UnifiedScanResultStoreData;
         const cardSelectionDataStub = null;
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionDataStub))
+            .setup(mock => mock(dataStub, cardSelectionDataStub, undefined))
             .returns(() => [])
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionDataStub)).toBeNull();
@@ -83,7 +83,7 @@ describe('ElementBasedViewModelCreator', () => {
             focusedResultUid: null,
         };
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionDataStub))
+            .setup(mock => mock(dataStub, cardSelectionDataStub, undefined))
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionDataStub)).toBeNull();
     });
@@ -116,7 +116,7 @@ describe('ElementBasedViewModelCreator', () => {
 
         const dataStub = {} as UnifiedScanResultStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionData))
+            .setup(mock => mock(dataStub, cardSelectionData, undefined))
             .returns(() => scanNodeResults)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
@@ -174,7 +174,7 @@ describe('ElementBasedViewModelCreator', () => {
 
             const dataStub = {} as UnifiedScanResultStoreData;
             convertStoreDataForScanNodeResultsCallbackMock
-                .setup(mock => mock(dataStub, cardSelectionData))
+                .setup(mock => mock(dataStub, cardSelectionData, undefined))
                 .returns(() => scanNodeResults)
                 .verifiable(Times.once());
             expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
@@ -257,7 +257,7 @@ describe('ElementBasedViewModelCreator', () => {
 
         const dataStub = {} as UnifiedScanResultStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionData))
+            .setup(mock => mock(dataStub, cardSelectionData, undefined))
             .returns(() => scanNodeResults)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(
@@ -310,7 +310,7 @@ describe('ElementBasedViewModelCreator', () => {
 
         const dataStub = {} as UnifiedScanResultStoreData;
         convertStoreDataForScanNodeResultsCallbackMock
-            .setup(mock => mock(dataStub, cardSelectionData))
+            .setup(mock => mock(dataStub, cardSelectionData, undefined))
             .returns(() => scanNodeResults)
             .verifiable(Times.once());
         expect(testSubject.getElementBasedViewModel(dataStub, cardSelectionData)).toEqual(

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -3,7 +3,10 @@
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlags } from 'common/feature-flags';
-import { ConvertStoreDataForScanNodeResultsCallback } from 'common/store-data-to-scan-node-result-converter';
+import {
+    ConvertAssessmentStoreDataToScanNodeResultsCallback,
+    ConvertUnifiedStoreDataToScanNodeResultsCallback,
+} from 'common/store-data-to-scan-node-result-converter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
 import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
@@ -34,7 +37,8 @@ describe('SelectorMapHelperTest', () => {
         typeof GetVisualizationInstancesForTabStops
     >;
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let convertStoreDataForScanNodeResultsCallbackMock: IMock<ConvertStoreDataForScanNodeResultsCallback>;
+    let convertUnifiedStoreDataForScanNodeResultsCallbackMock: IMock<ConvertUnifiedStoreDataToScanNodeResultsCallback>;
+    let convertAssessmentStoreDataForScanNodeResultsCallbackMock: IMock<ConvertAssessmentStoreDataToScanNodeResultsCallback>;
 
     const adHocVisualizationTypes = [
         VisualizationType.Headings,
@@ -54,13 +58,22 @@ describe('SelectorMapHelperTest', () => {
         getElementBasedViewModelMock = Mock.ofType<GetElementBasedViewModelCallback>();
         getVisualizationInstancesForTabStopsMock =
             Mock.ofType<typeof GetVisualizationInstancesForTabStops>();
-        convertStoreDataForScanNodeResultsCallbackMock =
-            Mock.ofType<ConvertStoreDataForScanNodeResultsCallback>(undefined, MockBehavior.Strict);
+        convertUnifiedStoreDataForScanNodeResultsCallbackMock =
+            Mock.ofType<ConvertUnifiedStoreDataToScanNodeResultsCallback>(
+                undefined,
+                MockBehavior.Strict,
+            );
+        convertAssessmentStoreDataForScanNodeResultsCallbackMock =
+            Mock.ofType<ConvertAssessmentStoreDataToScanNodeResultsCallback>(
+                undefined,
+                MockBehavior.Strict,
+            );
         testSubject = new SelectorMapHelper(
             visualizationConfigurationFactoryMock.object,
             getElementBasedViewModelMock.object,
             getVisualizationInstancesForTabStopsMock.object,
-            convertStoreDataForScanNodeResultsCallbackMock.object,
+            convertUnifiedStoreDataForScanNodeResultsCallbackMock.object,
+            convertAssessmentStoreDataForScanNodeResultsCallbackMock.object,
         );
     });
 
@@ -106,8 +119,8 @@ describe('SelectorMapHelperTest', () => {
             } as VisualizationRelatedStoreData;
 
             const scanResultsNodesStub = [];
-            convertStoreDataForScanNodeResultsCallbackMock
-                .setup(m => m(It.isAny(), It.isAny()))
+            convertUnifiedStoreDataForScanNodeResultsCallbackMock
+                .setup(m => m(It.isAny()))
                 .returns(() => scanResultsNodesStub);
             getElementBasedViewModelMock
                 .setup(gebvm =>
@@ -140,9 +153,9 @@ describe('SelectorMapHelperTest', () => {
 
             setupVisualizationConfigurationFactory(null, null, visualizationType, stepKey);
             const scanResultsNodesStub = [];
-            convertStoreDataForScanNodeResultsCallbackMock
+            convertAssessmentStoreDataForScanNodeResultsCallbackMock
                 .setup(m =>
-                    m(assessmentStoreDataStub, assessmentCardSelectionStoreDataStub, stepKey),
+                    m(assessmentStoreDataStub, stepKey, assessmentCardSelectionStoreDataStub),
                 )
                 .returns(() => scanResultsNodesStub);
             getElementBasedViewModelMock

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AutomatedChecks } from 'assessments/automated-checks/assessment';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlags } from 'common/feature-flags';
@@ -115,9 +114,9 @@ describe('SelectorMapHelperTest', () => {
 
     assessmentVisualizationTypes.forEach(visualizationType => {
         test(`getState: ${VisualizationType[visualizationType]}`, () => {
-            const stepKey = AutomatedChecks.key;
+            const stepKey = 'automatedChecks';
             const selectorMap = {
-                key1: { target: ['element1'] } as AssessmentVisualizationInstance,
+                automatedChecks: { target: ['element1'] } as AssessmentVisualizationInstance,
             };
             const assessmentStoreDataStub = {} as AssessmentStoreData;
             const assessmentCardSelectionStoreDataStub = {} as CardSelectionStoreData;
@@ -125,20 +124,15 @@ describe('SelectorMapHelperTest', () => {
             const storeData: VisualizationRelatedStoreData = {
                 assessmentStoreData: assessmentStoreDataStub,
                 assessmentCardSelectionStoreData: {
-                    [visualizationType]: assessmentCardSelectionStoreDataStub,
+                    [stepKey]: assessmentCardSelectionStoreDataStub,
                 },
                 featureFlagStoreData: { [FeatureFlags.automatedChecks]: true },
             } as unknown as VisualizationRelatedStoreData;
 
-            setupVisualizationConfigurationFactory(
-                null,
-                null,
-                visualizationType,
-                'automatedChecks',
-            );
+            setupVisualizationConfigurationFactory(null, null, visualizationType, stepKey);
             getElementBasedViewModelMock
                 .setup(gebvm =>
-                    gebvm(assessmentStoreDataStub, assessmentCardSelectionStoreDataStub),
+                    gebvm(assessmentStoreDataStub, assessmentCardSelectionStoreDataStub, stepKey),
                 )
                 .returns(() => selectorMap);
 

--- a/src/tests/unit/tests/reports/package/axe-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/axe-results-report.test.ts
@@ -71,8 +71,8 @@ describe('AxeResultReport', () => {
     };
     const mockCardsViewModel = Mock.ofType<CardsViewModel>();
     const mockGetCards = Mock.ofType<typeof getCardViewData>(null, MockBehavior.Strict);
-    mockGetCards.setup(fn => fn(It.isAny(), emptyCardSelectionViewData)).returns(() => mockCardsViewModel.object);
-
+    mockGetCards.setup(fn => fn(It.isAny(), emptyCardSelectionViewData, mockRules.object)).returns(() => mockCardsViewModel.object);
+    
     const expectedHTML = '<div>The Report!</div>';
     const mockReportHtmlGenerator = Mock.ofType<ReportHtmlGenerator>(null, MockBehavior.Strict);
     mockReportHtmlGenerator

--- a/src/tests/unit/tests/reports/package/axe-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/axe-results-report.test.ts
@@ -12,7 +12,7 @@ import { AxeResultsReport, AxeResultsReportDeps } from 'reports/package/axe-resu
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { ScanResults } from 'scanner/iruleresults';
 import { ResultDecorator } from 'scanner/result-decorator';
-import { Mock, MockBehavior } from 'typemoq';
+import { It, Mock, MockBehavior } from 'typemoq';
 
 describe('AxeResultReport', () => {
     const scanTimestamp = 'timestamp';
@@ -71,7 +71,7 @@ describe('AxeResultReport', () => {
     };
     const mockCardsViewModel = Mock.ofType<CardsViewModel>();
     const mockGetCards = Mock.ofType<typeof getCardViewData>(null, MockBehavior.Strict);
-    mockGetCards.setup(fn => fn({rules: mockRules.object, results: mockResults.object}, emptyCardSelectionViewData)).returns(() => mockCardsViewModel.object);
+    mockGetCards.setup(fn => fn(It.isAny(), emptyCardSelectionViewData)).returns(() => mockCardsViewModel.object);
 
     const expectedHTML = '<div>The Report!</div>';
     const mockReportHtmlGenerator = Mock.ofType<ReportHtmlGenerator>(null, MockBehavior.Strict);


### PR DESCRIPTION
#### Details

In previous PRs for this feature we introduced code that mixes up the assessment's test key and its visualization type. This PR fixes this bug by normalizing all logic to use the assessment test key. 

##### Motivation

Feature work

##### Context

Discovered while debugging/ integrating https://github.com/microsoft/accessibility-insights-web/pull/6510

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
