### PR TITLE
feat(automated-checks): send selected test key with card selection message payloads

### DIFF
--- a/src/DetailsView/assessment-functionality-switcher.ts
+++ b/src/DetailsView/assessment-functionality-switcher.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { BaseStore } from 'common/base-store';
-import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
 import { GetDetailsSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
@@ -16,7 +16,7 @@ import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-
 export type SharedAssessmentObjects = {
     provider: AssessmentsProvider;
     actionMessageCreator: AssessmentActionMessageCreator;
-    cardSelectionMessageCreator: AssessmentCardSelectionMessageCreator;
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
     navLinkHandler: NavLinkHandler;
     instanceTableHandler: AssessmentInstanceTableHandler;
     getAssessmentSummaryModelFromProviderAndStatusData: GetSelectedAssessmentSummaryModelFromProviderAndStatusData;
@@ -49,10 +49,9 @@ export class AssessmentFunctionalitySwitcher {
         return this.getSharedObjects().actionMessageCreator;
     };
 
-    public getAssessmentCardSelectionMessageCreator: () => AssessmentCardSelectionMessageCreator =
-        () => {
-            return this.getSharedObjects().cardSelectionMessageCreator;
-        };
+    public getAssessmentCardSelectionMessageCreator: () => CardSelectionMessageCreator = () => {
+        return this.getSharedObjects().cardSelectionMessageCreator;
+    };
 
     public getNavLinkHandler: () => NavLinkHandler = () => {
         return this.getSharedObjects().navLinkHandler;

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardsViewStoreData } from 'common/components/cards/cards-view-store-data';
-import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
 import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete-warnings';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
@@ -33,7 +33,7 @@ export type TestViewContainerDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
     automatedChecksCardSelectionMessageCreator: AutomatedChecksCardSelectionMessageCreator;
     needsReviewCardSelectionMessageCreator: NeedsReviewCardSelectionMessageCreator;
-    getAssessmentCardSelectionMessageCreator: () => AssessmentCardSelectionMessageCreator;
+    getAssessmentCardSelectionMessageCreator: () => CardSelectionMessageCreator;
 } & TestViewDeps &
     OverviewContainerDeps &
     AdhocTabStopsTestViewDeps;

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -34,6 +34,7 @@ import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unav
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
+import { AssessmentCardSelectionMessageCreatorWrapper } from 'common/message-creators/assessment-card-selection-message-creator-wrapper';
 import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
 import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { Messages } from 'common/messages';
@@ -590,7 +591,11 @@ if (tabId != null) {
             const assessmentObjects: SharedAssessmentObjects = {
                 provider: Assessments,
                 actionMessageCreator: assessmentActionMessageCreator,
-                cardSelectionMessageCreator: assessmentCardSelectionMessageCreator,
+                cardSelectionMessageCreator: new AssessmentCardSelectionMessageCreatorWrapper(
+                    assessmentCardSelectionMessageCreator,
+                    visualizationConfigurationFactory,
+                    assessmentStore,
+                ),
                 navLinkHandler: new NavLinkHandler(
                     detailsViewActionMessageCreator,
                     assessmentActionMessageCreator,
@@ -604,7 +609,11 @@ if (tabId != null) {
             const quickAssessObjects: SharedAssessmentObjects = {
                 provider: quickAssessProvider,
                 actionMessageCreator: quickAssessActionMessageCreator,
-                cardSelectionMessageCreator: quickAssessCardSelectionMessageCreator,
+                cardSelectionMessageCreator: new AssessmentCardSelectionMessageCreatorWrapper(
+                    quickAssessCardSelectionMessageCreator,
+                    visualizationConfigurationFactory,
+                    quickAssessStore,
+                ),
                 navLinkHandler: new NavLinkHandler(
                     detailsViewActionMessageCreator,
                     quickAssessActionMessageCreator,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -688,8 +688,6 @@ if (tabId != null) {
                 navigatorUtils: navigatorUtils,
                 automatedChecksCardSelectionMessageCreator,
                 needsReviewCardSelectionMessageCreator,
-                assessmentCardSelectionMessageCreator,
-                quickAssessCardSelectionMessageCreator,
                 getCardSelectionViewData: getCardSelectionViewData,
                 cardsVisualizationModifierButtons: ExpandCollapseVisualHelperModifierButtons,
                 allUrlsPermissionHandler: new AllUrlsPermissionHandler(

--- a/src/common/message-creators/assessment-card-selection-message-creator-wrapper.ts
+++ b/src/common/message-creators/assessment-card-selection-message-creator-wrapper.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BaseStore } from 'common/base-store';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+
+export const NO_ASSESSMENT_STORE_DATA_ERROR = 'no assessment store data';
+
+export class AssessmentCardSelectionMessageCreatorWrapper implements CardSelectionMessageCreator {
+    constructor(
+        private assessmentCardSelectionMessageCreator: AssessmentCardSelectionMessageCreator,
+        private visualizationFactory: VisualizationConfigurationFactory,
+        private assessmentStore: BaseStore<AssessmentStoreData, Promise<void>>,
+    ) {}
+
+    public toggleVisualHelper = (event: SupportedMouseEvent) => {
+        const testKey = this.getSelectedTestKey();
+        return this.assessmentCardSelectionMessageCreator.toggleVisualHelper(event, testKey);
+    };
+
+    public expandAllRules = (event: SupportedMouseEvent) => {
+        const testKey = this.getSelectedTestKey();
+        return this.assessmentCardSelectionMessageCreator.toggleVisualHelper(event, testKey);
+    };
+
+    public collapseAllRules = (event: SupportedMouseEvent) => {
+        const testKey = this.getSelectedTestKey();
+        return this.assessmentCardSelectionMessageCreator.toggleVisualHelper(event, testKey);
+    };
+
+    public toggleCardSelection = (
+        ruleId: string,
+        resultInstanceUid: string,
+        event: React.SyntheticEvent,
+    ) => {
+        const testKey = this.getSelectedTestKey();
+        return this.assessmentCardSelectionMessageCreator.toggleCardSelection(
+            ruleId,
+            resultInstanceUid,
+            event,
+            testKey,
+        );
+    };
+
+    public toggleRuleExpandCollapse = (ruleId: string, event: React.SyntheticEvent) => {
+        const testKey = this.getSelectedTestKey();
+        return this.assessmentCardSelectionMessageCreator.toggleRuleExpandCollapse(
+            ruleId,
+            event,
+            testKey,
+        );
+    };
+
+    private getSelectedTestKey = () => {
+        const assessmentStoreState = this.assessmentStore.getState();
+
+        if (assessmentStoreState == null) {
+            throw NO_ASSESSMENT_STORE_DATA_ERROR;
+        }
+
+        const selectedTest = this.assessmentStore.getState().assessmentNavState.selectedTestType;
+        const testKey = this.visualizationFactory.getConfiguration(selectedTest).key;
+        return testKey;
+    };
+}

--- a/src/common/message-creators/assessment-card-selection-message-creator-wrapper.ts
+++ b/src/common/message-creators/assessment-card-selection-message-creator-wrapper.ts
@@ -24,12 +24,12 @@ export class AssessmentCardSelectionMessageCreatorWrapper implements CardSelecti
 
     public expandAllRules = (event: SupportedMouseEvent) => {
         const testKey = this.getSelectedTestKey();
-        return this.assessmentCardSelectionMessageCreator.toggleVisualHelper(event, testKey);
+        return this.assessmentCardSelectionMessageCreator.expandAllRules(event, testKey);
     };
 
     public collapseAllRules = (event: SupportedMouseEvent) => {
         const testKey = this.getSelectedTestKey();
-        return this.assessmentCardSelectionMessageCreator.toggleVisualHelper(event, testKey);
+        return this.assessmentCardSelectionMessageCreator.collapseAllRules(event, testKey);
     };
 
     public toggleCardSelection = (
@@ -62,7 +62,7 @@ export class AssessmentCardSelectionMessageCreatorWrapper implements CardSelecti
             throw NO_ASSESSMENT_STORE_DATA_ERROR;
         }
 
-        const selectedTest = this.assessmentStore.getState().assessmentNavState.selectedTestType;
+        const selectedTest = assessmentStoreState.assessmentNavState.selectedTestType;
         const testKey = this.visualizationFactory.getConfiguration(selectedTest).key;
         return testKey;
     };

--- a/src/common/message-creators/assessment-card-selection-message-creator.ts
+++ b/src/common/message-creators/assessment-card-selection-message-creator.ts
@@ -7,12 +7,11 @@ import {
     AssessmentSingleRuleExpandCollapsePayload,
 } from 'background/actions/action-payloads';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { AssessmentCardSelectionMessages } from 'common/messages';
 import { SupportedMouseEvent, TelemetryDataFactory } from 'common/telemetry-data-factory';
 
-export class AssessmentCardSelectionMessageCreator implements CardSelectionMessageCreator {
+export class AssessmentCardSelectionMessageCreator {
     constructor(
         private readonly dispatcher: ActionMessageDispatcher,
         private readonly telemetryFactory: TelemetryDataFactory,

--- a/src/common/message-creators/card-selection-message-creator.ts
+++ b/src/common/message-creators/card-selection-message-creator.ts
@@ -8,14 +8,9 @@ export interface CardSelectionMessageCreator {
         ruleId: string,
         resultInstanceUid: string,
         event: React.SyntheticEvent,
-        testKey?: string,
     ) => void;
-    toggleRuleExpandCollapse: (
-        ruleId: string,
-        event: React.SyntheticEvent,
-        testKey?: string,
-    ) => void;
-    collapseAllRules: (event: SupportedMouseEvent, testKey?: string) => void;
-    expandAllRules: (event: SupportedMouseEvent, testKey?: string) => void;
-    toggleVisualHelper: (event: SupportedMouseEvent, testKey?: string) => void;
+    toggleRuleExpandCollapse: (ruleId: string, event: React.SyntheticEvent) => void;
+    collapseAllRules: (event: SupportedMouseEvent) => void;
+    expandAllRules: (event: SupportedMouseEvent) => void;
+    toggleVisualHelper: (event: SupportedMouseEvent) => void;
 }

--- a/src/tests/unit/tests/DetailsView/assessment-functionality-switcher.test.ts
+++ b/src/tests/unit/tests/DetailsView/assessment-functionality-switcher.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { AssessmentActionMessageCreator } from 'DetailsView/actions/assessment-action-message-creator';
@@ -114,8 +114,7 @@ describe(AssessmentFunctionalitySwitcher, () => {
             assessmentObjectsStub = {
                 provider: Mock.ofType<AssessmentsProvider>().object,
                 actionMessageCreator: Mock.ofType<AssessmentActionMessageCreator>().object,
-                cardSelectionMessageCreator:
-                    Mock.ofType<AssessmentCardSelectionMessageCreator>().object,
+                cardSelectionMessageCreator: Mock.ofType<CardSelectionMessageCreator>().object,
                 navLinkHandler: Mock.ofType<NavLinkHandler>().object,
                 instanceTableHandler: Mock.ofType<AssessmentInstanceTableHandler>().object,
                 getAssessmentSummaryModelFromProviderAndStatusData:

--- a/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
-import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
 import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creators/automated-checks-card-selection-message-creator';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -25,7 +25,7 @@ describe('TestViewContainer', () => {
     const automatedChecksCardSelectionMessageCreatorStub =
         {} as AutomatedChecksCardSelectionMessageCreator;
     const needsReviewCardSelectionMessageCreatorStub = {} as NeedsReviewCardSelectionMessageCreator;
-    const assessmentCardSelectionMessageCreatorStub = {} as AssessmentCardSelectionMessageCreator;
+    const assessmentCardSelectionMessageCreatorStub = {} as CardSelectionMessageCreator;
     let configStub: VisualizationConfiguration;
     let configFactoryStub: VisualizationConfigurationFactory;
     let props: TestViewContainerProps;
@@ -33,9 +33,7 @@ describe('TestViewContainer', () => {
         (provider: TestViewContainerProvider, props: TestViewContainerProviderProps) => JSX.Element
     >;
     let testViewContainerProviderMock: IMock<TestViewContainerProvider>;
-    let getAssessmentCardSelectionMessageCreatorMock: IMock<
-        () => AssessmentCardSelectionMessageCreator
-    >;
+    let getAssessmentCardSelectionMessageCreatorMock: IMock<() => CardSelectionMessageCreator>;
 
     beforeEach(() => {
         getTestViewContainerMock = Mock.ofInstance((provider, props) => null);

--- a/src/tests/unit/tests/common/message-creators/assessment-card-selection-message-creator-wrapper.test.ts
+++ b/src/tests/unit/tests/common/message-creators/assessment-card-selection-message-creator-wrapper.test.ts
@@ -50,6 +50,19 @@ describe('AssessmentCardSelectionMessageCreatorWrapper', () => {
         visualizationConfigurationFactoryMock.verifyAll();
     });
 
+    test('errors when assessment store data is null', () => {
+        visualizationConfigurationFactoryMock.reset();
+        assessmentStoreMock.reset();
+        assessmentStoreMock
+            .setup(asm => asm.getState())
+            .returns(() => null)
+            .verifiable(Times.once());
+
+        expect(() => testSubject.toggleVisualHelper(eventStub)).toThrowError(
+            'no assessment store data',
+        );
+    });
+
     test('toggleVisualHelper', () => {
         assessmentCardSelectionMessageCreatorMock
             .setup(m => m.toggleVisualHelper(eventStub, selectedTestKeyStub))

--- a/src/tests/unit/tests/common/message-creators/assessment-card-selection-message-creator-wrapper.test.ts
+++ b/src/tests/unit/tests/common/message-creators/assessment-card-selection-message-creator-wrapper.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentStore } from 'background/stores/assessment-store';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { AssessmentCardSelectionMessageCreator } from 'common/message-creators/assessment-card-selection-message-creator';
+import { AssessmentCardSelectionMessageCreatorWrapper } from 'common/message-creators/assessment-card-selection-message-creator-wrapper';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe('AssessmentCardSelectionMessageCreatorWrapper', () => {
+    let testSubject: AssessmentCardSelectionMessageCreatorWrapper;
+    let assessmentCardSelectionMessageCreatorMock: IMock<AssessmentCardSelectionMessageCreator>;
+    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
+    let assessmentStoreMock: IMock<AssessmentStore>;
+    const selectedTestTypeStub = 0;
+    const selectedTestKeyStub = 'test-key';
+    const visualizationConfigurationStub = {
+        key: selectedTestKeyStub,
+    } as VisualizationConfiguration;
+    const assessmentStoreStateStub = {
+        assessmentNavState: { selectedTestType: selectedTestTypeStub },
+    } as AssessmentStoreData;
+    const eventStub: React.SyntheticEvent = {} as React.SyntheticEvent;
+
+    beforeEach(() => {
+        assessmentCardSelectionMessageCreatorMock =
+            Mock.ofType<AssessmentCardSelectionMessageCreator>();
+        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
+        visualizationConfigurationFactoryMock
+            .setup(vcf => vcf.getConfiguration(selectedTestTypeStub))
+            .returns(() => visualizationConfigurationStub)
+            .verifiable(Times.once());
+        assessmentStoreMock = Mock.ofType(AssessmentStore);
+        assessmentStoreMock
+            .setup(asm => asm.getState())
+            .returns(() => assessmentStoreStateStub)
+            .verifiable(Times.once());
+
+        testSubject = new AssessmentCardSelectionMessageCreatorWrapper(
+            assessmentCardSelectionMessageCreatorMock.object,
+            visualizationConfigurationFactoryMock.object,
+            assessmentStoreMock.object,
+        );
+    });
+
+    afterEach(() => {
+        assessmentCardSelectionMessageCreatorMock.verifyAll();
+        assessmentStoreMock.verifyAll();
+        visualizationConfigurationFactoryMock.verifyAll();
+    });
+
+    test('toggleVisualHelper', () => {
+        assessmentCardSelectionMessageCreatorMock
+            .setup(m => m.toggleVisualHelper(eventStub, selectedTestKeyStub))
+            .verifiable(Times.once());
+
+        testSubject.toggleVisualHelper(eventStub);
+    });
+
+    test('expandAllRules', () => {
+        assessmentCardSelectionMessageCreatorMock
+            .setup(m => m.expandAllRules(eventStub, selectedTestKeyStub))
+            .verifiable(Times.once());
+
+        testSubject.expandAllRules(eventStub);
+    });
+
+    test('collapseAllRules', () => {
+        assessmentCardSelectionMessageCreatorMock
+            .setup(m => m.collapseAllRules(eventStub, selectedTestKeyStub))
+            .verifiable(Times.once());
+
+        testSubject.collapseAllRules(eventStub);
+    });
+
+    test('toggleCardSelection', () => {
+        const ruleId = 'test-rule-id';
+        const resultInstanceUid = 'test-uid';
+        assessmentCardSelectionMessageCreatorMock
+            .setup(m =>
+                m.toggleCardSelection(ruleId, resultInstanceUid, eventStub, selectedTestKeyStub),
+            )
+            .verifiable(Times.once());
+
+        testSubject.toggleCardSelection(ruleId, resultInstanceUid, eventStub);
+    });
+
+    test('toggleRuleExpandCollapse', () => {
+        const ruleId = 'test-rule-id';
+        assessmentCardSelectionMessageCreatorMock
+            .setup(m => m.toggleRuleExpandCollapse(ruleId, eventStub, selectedTestKeyStub))
+            .verifiable(Times.once());
+
+        testSubject.toggleRuleExpandCollapse(ruleId, eventStub);
+    });
+});


### PR DESCRIPTION
#### Details

With the addition of the AssessmentCardSelectionStore and its corresponding infrastructure (https://github.com/microsoft/accessibility-insights-web/pull/6457), we added the testKey parameter to card selection message payloads, but right now the test key is never populated. This PR adds the logic to populate the testKey. 

##### Motivation

Feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
