### PR TITLE
feat(automated-checks): remove storeDataKey and make keys consistent across assessment and visualization configuration objects

### DIFF
--- a/src/assessments/adaptable-content/assessment.tsx
+++ b/src/assessments/adaptable-content/assessment.tsx
@@ -56,5 +56,4 @@ export const AdaptableContentAssessment: Assessment = AssessmentBuilder.Assisted
         TextSpacing,
         HoverFocusContent,
     ],
-    storeDataKey: 'adaptableContentAssessment',
 });

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -147,12 +147,12 @@ export class AssessmentBuilder {
         };
 
         const visualizationConfiguration: AssessmentVisualizationConfiguration = {
+            key,
             testViewType: 'Assessment',
             enableTest: AssessmentBuilder.enableTest,
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,
             getAssessmentData: data => data.assessments[key],
-            key: `${key}Assessment`,
             getAnalyzer: getAnalyzer,
             visualizationInstanceProcessor: () => VisualizationInstanceProcessor.nullProcessor,
             getDrawer: provider => provider.createNullDrawer(),
@@ -232,6 +232,7 @@ export class AssessmentBuilder {
             ((provider, props) => provider.createAssessmentTestViewContainer(props));
 
         const visualizationConfiguration: AssessmentVisualizationConfiguration = {
+            key,
             testViewType: 'Assessment',
             getAssessmentData: data => data.assessments[key],
             setAssessmentData: (data, selectorMap, instanceMap) => {
@@ -244,7 +245,6 @@ export class AssessmentBuilder {
             getTestStatus: AssessmentBuilder.getTestStatus,
             telemetryProcessor: factory => factory.forAssessmentRequirementScan,
             ...assessment.visualizationConfiguration,
-            key: assessment.storeDataKey,
             getAnalyzer: getAnalyzer,
             visualizationInstanceProcessor:
                 AssessmentBuilder.getVisualizationInstanceProcessor(requirements),

--- a/src/assessments/automated-checks/assessment.tsx
+++ b/src/assessments/automated-checks/assessment.tsx
@@ -31,7 +31,6 @@ const config: AssistedAssessment = {
             testing.
         </>
     ),
-    storeDataKey: 'automatedChecks',
     visualizationType: VisualizationType.AutomatedChecks,
     initialDataCreator: createAutomatedChecksInitialAssessmentTestData,
     gettingStarted,

--- a/src/assessments/color/assessment.tsx
+++ b/src/assessments/color/assessment.tsx
@@ -35,5 +35,4 @@ export const ColorSensoryAssessment: Assessment = AssessmentBuilder.Assisted({
     visualizationType: VisualizationType.ColorSensoryAssessment,
     guidance,
     requirements: [UseOfColor, SensoryCharacteristics, AuditoryCues, Flashing],
-    storeDataKey: 'colorSensoryAssessment',
 });

--- a/src/assessments/contrast/assessment.tsx
+++ b/src/assessments/contrast/assessment.tsx
@@ -33,5 +33,4 @@ export const ContrastAssessment: Assessment = AssessmentBuilder.Assisted({
     guidance,
     visualizationType: VisualizationType.ContrastAssessment,
     requirements: [UIComponents, StateChanges, Graphics],
-    storeDataKey: 'contrastAssessment',
 });

--- a/src/assessments/custom-widgets/assessment.tsx
+++ b/src/assessments/custom-widgets/assessment.tsx
@@ -53,5 +53,4 @@ export const CustomWidgets: Assessment = AssessmentBuilder.Assisted({
         Cues,
         KeyboardInteraction,
     ],
-    storeDataKey: 'customWidgetsAssessment',
 });

--- a/src/assessments/headings/assessment.tsx
+++ b/src/assessments/headings/assessment.tsx
@@ -53,6 +53,5 @@ export const HeadingsAssessment: Assessment = AssessmentBuilder.Assisted({
     title,
     guidance,
     requirements: [HeadingFunction, NoMissingHeadings, HeadingLevel],
-    storeDataKey: 'headingsAssessment',
     isEnabled: true,
 });

--- a/src/assessments/images/assessment.tsx
+++ b/src/assessments/images/assessment.tsx
@@ -30,5 +30,4 @@ export const ImagesAssessment: Assessment = AssessmentBuilder.Assisted({
     gettingStarted,
     guidance,
     requirements: [ImageFunction, TextAlternative, ImagesOfText, Captchas],
-    storeDataKey: 'imageAssessment',
 });

--- a/src/assessments/keyboard-interaction/assessment.tsx
+++ b/src/assessments/keyboard-interaction/assessment.tsx
@@ -52,7 +52,6 @@ export const KeyboardInteraction: Assessment = AssessmentBuilder.Assisted({
         NoKeystrokeTiming,
         CharacterKeyShortcuts,
     ],
-    storeDataKey: 'keyboardInteractionAssessment',
     visualizationConfiguration: {
         key: key,
         analyzerProgressMessageType: Messages.Assessment.TabbedElementAdded,

--- a/src/assessments/landmarks/assessment.tsx
+++ b/src/assessments/landmarks/assessment.tsx
@@ -52,5 +52,4 @@ export const LandmarksAssessment: Assessment = AssessmentBuilder.Assisted({
     guidance,
     visualizationType: VisualizationType.LandmarksAssessment,
     requirements: [LandmarkRoles, PrimaryContent, NoRepeatingContent],
-    storeDataKey: 'landmarksAssessment',
 });

--- a/src/assessments/links/assessments.tsx
+++ b/src/assessments/links/assessments.tsx
@@ -48,5 +48,4 @@ export const LinksAssessment = AssessmentBuilder.Assisted({
     guidance,
     visualizationType: VisualizationType.LinksAssessment,
     requirements: [LinkFunction, LinkPurpose, LabelInName],
-    storeDataKey: 'linksAssessment',
 });

--- a/src/assessments/native-widgets/assessment.tsx
+++ b/src/assessments/native-widgets/assessment.tsx
@@ -47,5 +47,4 @@ export const NativeWidgetsAssessment: Assessment = AssessmentBuilder.Assisted({
     gettingStarted,
     guidance,
     requirements: [WidgetFunction, Instructions, ExpectedInput, Cues, Autocomplete],
-    storeDataKey: 'nativeWidgetsAssessment',
 });

--- a/src/assessments/page/assessment.tsx
+++ b/src/assessments/page/assessment.tsx
@@ -28,5 +28,4 @@ export const PageAssessment: Assessment = AssessmentBuilder.Assisted({
     title: pageAssessmentTitle,
     guidance,
     requirements: [PageTitle, FrameTitle, GeneralNavigation],
-    storeDataKey: 'pageAssessment',
 });

--- a/src/assessments/pointer-motion/assessment.tsx
+++ b/src/assessments/pointer-motion/assessment.tsx
@@ -30,5 +30,4 @@ export const PointerMotionAssessment: Assessment = AssessmentBuilder.Assisted({
     guidance,
     visualizationType: VisualizationType.PointerMotionAssessment,
     requirements: [PointerGestures, PointerCancellation, MotionOperation],
-    storeDataKey: 'pointerMotionAssessment',
 });

--- a/src/assessments/semantics/assessment.tsx
+++ b/src/assessments/semantics/assessment.tsx
@@ -51,5 +51,4 @@ export const SemanticsAssessment = AssessmentBuilder.Assisted({
         SemanticsQuotes,
         SemanticsLetterSpacing,
     ],
-    storeDataKey: 'semanticsAssessment',
 });

--- a/src/assessments/sequence/assessment.tsx
+++ b/src/assessments/sequence/assessment.tsx
@@ -32,5 +32,4 @@ export const SequenceAssessment: Assessment = AssessmentBuilder.Assisted({
     guidance,
     visualizationType: VisualizationType.SequenceAssessment,
     requirements: [CssPositioning, LayoutTables, Columns],
-    storeDataKey: 'sequenceAssessment',
 });

--- a/src/assessments/types/iassessment.ts
+++ b/src/assessments/types/iassessment.ts
@@ -28,7 +28,6 @@ interface BaseAssessment {
 export interface ManualAssessment extends BaseAssessment {}
 
 export interface AssistedAssessment extends BaseAssessment {
-    storeDataKey: string;
     visualizationConfiguration?: Partial<AssessmentVisualizationConfiguration>;
     getTestViewContainer?: (
         provider: TestViewContainerProvider,

--- a/src/assessments/visible-focus-order/assessment.tsx
+++ b/src/assessments/visible-focus-order/assessment.tsx
@@ -38,7 +38,6 @@ export const VisibleFocusOrderAssessment: Assessment = AssessmentBuilder.Assiste
     guidance,
     visualizationType: VisualizationType.VisibleFocusOrderAssessment,
     requirements: [VisibleFocus, RevealingContent, ModalDialogs, ClosingContent, FocusOrder],
-    storeDataKey: 'visibleFocusOrderAssessment',
     visualizationConfiguration: {
         key: key,
         analyzerProgressMessageType: Messages.Assessment.TabbedElementAdded,

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderForRequirements } from 'assessments/assessments-requirements-filter';
+import { HeadingsAssessment } from 'assessments/headings/assessment';
+import { LandmarksAssessment } from 'assessments/landmarks/assessment';
 import { QuickAssessRequirementMap } from 'assessments/quick-assess-requirements';
 import { InitialVisualizationStoreDataGenerator } from 'background/initial-visualization-store-data-generator';
 import { VisualizationStore } from 'background/stores/visualization-store';
@@ -57,7 +59,11 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
     }
 
     public withLandmarksAssessment(enable: boolean, step: string): VisualizationStoreDataBuilder {
-        return this.withAssessment(this.data.tests.assessments.landmarksAssessment, enable, step);
+        return this.withAssessment(
+            this.data.tests.assessments[LandmarksAssessment.key],
+            enable,
+            step,
+        );
     }
 
     public withTabStopsEnable(): VisualizationStoreDataBuilder {
@@ -71,7 +77,11 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
     }
 
     public withHeadingsAssessment(enable: boolean, step: string): VisualizationStoreDataBuilder {
-        return this.withAssessment(this.data.tests.assessments.headingsAssessment, enable, step);
+        return this.withAssessment(
+            this.data.tests.assessments[HeadingsAssessment.key],
+            enable,
+            step,
+        );
     }
 
     public withNeedsReviewEnable(): VisualizationStoreDataBuilder {

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -242,51 +242,47 @@ exports[`DetailsViewBody render render 1`] = `
               },
             },
             "assessments": {
-              "adaptableContentAssessment": {
+              "audioVideoOnly": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "audioVideoOnlyAssessment": {
+              "automated-checks": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "automatedChecks": {
+              "color": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "colorSensoryAssessment": {
+              "contrast": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "contrastAssessment": {
+              "customWidgets": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "customWidgetsAssessment": {
+              "errors": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "errorsAssessment": {
+              "headings": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "headingsAssessment": {
+              "images": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "imageAssessment": {
+              "keyboardInteraction": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "keyboardInteractionAssessment": {
+              "landmarks": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "landmarksAssessment": {
-                "enabled": false,
-                "stepStatus": {},
-              },
-              "languageAssessment": {
+              "language": {
                 "enabled": false,
                 "stepStatus": {},
               },
@@ -294,31 +290,31 @@ exports[`DetailsViewBody render render 1`] = `
                 "enabled": false,
                 "stepStatus": {},
               },
-              "liveMultimediaAssessment": {
+              "liveMultimedia": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "nativeWidgetsAssessment": {
+              "nativeWidgets": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "pageAssessment": {
+              "page": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "parsingAssessment": {
+              "parsing": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "pointerMotionAssessment": {
+              "pointerMotion": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "prerecordedMultimediaAssessment": {
+              "prerecordedMultimedia": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "repetitiveContentAssessment": {
+              "repetitiveContent": {
                 "enabled": false,
                 "stepStatus": {},
               },
@@ -326,41 +322,41 @@ exports[`DetailsViewBody render render 1`] = `
                 "enabled": false,
                 "stepStatus": {},
               },
-              "sequenceAssessment": {
+              "sequence": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "timedEventsAssessment": {
+              "textLegibility": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "visibleFocusOrderAssessment": {
+              "timedEvents": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "visibleFocusOrder": {
                 "enabled": false,
                 "stepStatus": {},
               },
             },
             "quickAssess": {
-              "adaptableContentAssessment": {
+              "automated-checks": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "automatedChecks": {
+              "contrast": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "contrastAssessment": {
+              "headings": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "headingsAssessment": {
+              "images": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "imageAssessment": {
-                "enabled": false,
-                "stepStatus": {},
-              },
-              "keyboardInteractionAssessment": {
+              "keyboardInteraction": {
                 "enabled": false,
                 "stepStatus": {},
               },
@@ -368,15 +364,19 @@ exports[`DetailsViewBody render render 1`] = `
                 "enabled": false,
                 "stepStatus": {},
               },
-              "nativeWidgetsAssessment": {
+              "nativeWidgets": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "repetitiveContentAssessment": {
+              "repetitiveContent": {
                 "enabled": false,
                 "stepStatus": {},
               },
-              "visibleFocusOrderAssessment": {
+              "textLegibility": {
+                "enabled": false,
+                "stepStatus": {},
+              },
+              "visibleFocusOrder": {
                 "enabled": false,
                 "stepStatus": {},
               },
@@ -621,51 +621,47 @@ exports[`DetailsViewBody render render 1`] = `
                 },
               },
               "assessments": {
-                "adaptableContentAssessment": {
+                "audioVideoOnly": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "audioVideoOnlyAssessment": {
+                "automated-checks": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "automatedChecks": {
+                "color": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "colorSensoryAssessment": {
+                "contrast": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "contrastAssessment": {
+                "customWidgets": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "customWidgetsAssessment": {
+                "errors": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "errorsAssessment": {
+                "headings": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "headingsAssessment": {
+                "images": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "imageAssessment": {
+                "keyboardInteraction": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "keyboardInteractionAssessment": {
+                "landmarks": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "landmarksAssessment": {
-                  "enabled": false,
-                  "stepStatus": {},
-                },
-                "languageAssessment": {
+                "language": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -673,31 +669,31 @@ exports[`DetailsViewBody render render 1`] = `
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "liveMultimediaAssessment": {
+                "liveMultimedia": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "nativeWidgetsAssessment": {
+                "nativeWidgets": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "pageAssessment": {
+                "page": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "parsingAssessment": {
+                "parsing": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "pointerMotionAssessment": {
+                "pointerMotion": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "prerecordedMultimediaAssessment": {
+                "prerecordedMultimedia": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "repetitiveContentAssessment": {
+                "repetitiveContent": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -705,41 +701,41 @@ exports[`DetailsViewBody render render 1`] = `
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "sequenceAssessment": {
+                "sequence": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "timedEventsAssessment": {
+                "textLegibility": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "visibleFocusOrderAssessment": {
+                "timedEvents": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "visibleFocusOrder": {
                   "enabled": false,
                   "stepStatus": {},
                 },
               },
               "quickAssess": {
-                "adaptableContentAssessment": {
+                "automated-checks": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "automatedChecks": {
+                "contrast": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "contrastAssessment": {
+                "headings": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "headingsAssessment": {
+                "images": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "imageAssessment": {
-                  "enabled": false,
-                  "stepStatus": {},
-                },
-                "keyboardInteractionAssessment": {
+                "keyboardInteraction": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -747,15 +743,19 @@ exports[`DetailsViewBody render render 1`] = `
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "nativeWidgetsAssessment": {
+                "nativeWidgets": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "repetitiveContentAssessment": {
+                "repetitiveContent": {
                   "enabled": false,
                   "stepStatus": {},
                 },
-                "visibleFocusOrderAssessment": {
+                "textLegibility": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "visibleFocusOrder": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -1015,51 +1015,47 @@ exports[`DetailsViewBody render render 1`] = `
                     },
                   },
                   "assessments": {
-                    "adaptableContentAssessment": {
+                    "audioVideoOnly": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "audioVideoOnlyAssessment": {
+                    "automated-checks": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "automatedChecks": {
+                    "color": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "colorSensoryAssessment": {
+                    "contrast": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "contrastAssessment": {
+                    "customWidgets": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "customWidgetsAssessment": {
+                    "errors": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "errorsAssessment": {
+                    "headings": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "headingsAssessment": {
+                    "images": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "imageAssessment": {
+                    "keyboardInteraction": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "keyboardInteractionAssessment": {
+                    "landmarks": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "landmarksAssessment": {
-                      "enabled": false,
-                      "stepStatus": {},
-                    },
-                    "languageAssessment": {
+                    "language": {
                       "enabled": false,
                       "stepStatus": {},
                     },
@@ -1067,31 +1063,31 @@ exports[`DetailsViewBody render render 1`] = `
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "liveMultimediaAssessment": {
+                    "liveMultimedia": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "nativeWidgetsAssessment": {
+                    "nativeWidgets": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "pageAssessment": {
+                    "page": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "parsingAssessment": {
+                    "parsing": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "pointerMotionAssessment": {
+                    "pointerMotion": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "prerecordedMultimediaAssessment": {
+                    "prerecordedMultimedia": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "repetitiveContentAssessment": {
+                    "repetitiveContent": {
                       "enabled": false,
                       "stepStatus": {},
                     },
@@ -1099,41 +1095,41 @@ exports[`DetailsViewBody render render 1`] = `
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "sequenceAssessment": {
+                    "sequence": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "timedEventsAssessment": {
+                    "textLegibility": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "visibleFocusOrderAssessment": {
+                    "timedEvents": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "visibleFocusOrder": {
                       "enabled": false,
                       "stepStatus": {},
                     },
                   },
                   "quickAssess": {
-                    "adaptableContentAssessment": {
+                    "automated-checks": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "automatedChecks": {
+                    "contrast": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "contrastAssessment": {
+                    "headings": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "headingsAssessment": {
+                    "images": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "imageAssessment": {
-                      "enabled": false,
-                      "stepStatus": {},
-                    },
-                    "keyboardInteractionAssessment": {
+                    "keyboardInteraction": {
                       "enabled": false,
                       "stepStatus": {},
                     },
@@ -1141,15 +1137,19 @@ exports[`DetailsViewBody render render 1`] = `
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "nativeWidgetsAssessment": {
+                    "nativeWidgets": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "repetitiveContentAssessment": {
+                    "repetitiveContent": {
                       "enabled": false,
                       "stepStatus": {},
                     },
-                    "visibleFocusOrderAssessment": {
+                    "textLegibility": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "visibleFocusOrder": {
                       "enabled": false,
                       "stepStatus": {},
                     },

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -299,51 +299,47 @@ exports[`DetailsViewContent render renders normally 1`] = `
             },
           },
           "assessments": {
-            "adaptableContentAssessment": {
+            "audioVideoOnly": {
               "enabled": false,
               "stepStatus": {},
             },
-            "audioVideoOnlyAssessment": {
+            "automated-checks": {
               "enabled": false,
               "stepStatus": {},
             },
-            "automatedChecks": {
+            "color": {
               "enabled": false,
               "stepStatus": {},
             },
-            "colorSensoryAssessment": {
+            "contrast": {
               "enabled": false,
               "stepStatus": {},
             },
-            "contrastAssessment": {
+            "customWidgets": {
               "enabled": false,
               "stepStatus": {},
             },
-            "customWidgetsAssessment": {
+            "errors": {
               "enabled": false,
               "stepStatus": {},
             },
-            "errorsAssessment": {
+            "headings": {
               "enabled": false,
               "stepStatus": {},
             },
-            "headingsAssessment": {
+            "images": {
               "enabled": false,
               "stepStatus": {},
             },
-            "imageAssessment": {
+            "keyboardInteraction": {
               "enabled": false,
               "stepStatus": {},
             },
-            "keyboardInteractionAssessment": {
+            "landmarks": {
               "enabled": false,
               "stepStatus": {},
             },
-            "landmarksAssessment": {
-              "enabled": false,
-              "stepStatus": {},
-            },
-            "languageAssessment": {
+            "language": {
               "enabled": false,
               "stepStatus": {},
             },
@@ -351,31 +347,31 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "enabled": false,
               "stepStatus": {},
             },
-            "liveMultimediaAssessment": {
+            "liveMultimedia": {
               "enabled": false,
               "stepStatus": {},
             },
-            "nativeWidgetsAssessment": {
+            "nativeWidgets": {
               "enabled": false,
               "stepStatus": {},
             },
-            "pageAssessment": {
+            "page": {
               "enabled": false,
               "stepStatus": {},
             },
-            "parsingAssessment": {
+            "parsing": {
               "enabled": false,
               "stepStatus": {},
             },
-            "pointerMotionAssessment": {
+            "pointerMotion": {
               "enabled": false,
               "stepStatus": {},
             },
-            "prerecordedMultimediaAssessment": {
+            "prerecordedMultimedia": {
               "enabled": false,
               "stepStatus": {},
             },
-            "repetitiveContentAssessment": {
+            "repetitiveContent": {
               "enabled": false,
               "stepStatus": {},
             },
@@ -383,41 +379,41 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "enabled": false,
               "stepStatus": {},
             },
-            "sequenceAssessment": {
+            "sequence": {
               "enabled": false,
               "stepStatus": {},
             },
-            "timedEventsAssessment": {
+            "textLegibility": {
               "enabled": false,
               "stepStatus": {},
             },
-            "visibleFocusOrderAssessment": {
+            "timedEvents": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "visibleFocusOrder": {
               "enabled": false,
               "stepStatus": {},
             },
           },
           "quickAssess": {
-            "adaptableContentAssessment": {
+            "automated-checks": {
               "enabled": false,
               "stepStatus": {},
             },
-            "automatedChecks": {
+            "contrast": {
               "enabled": false,
               "stepStatus": {},
             },
-            "contrastAssessment": {
+            "headings": {
               "enabled": false,
               "stepStatus": {},
             },
-            "headingsAssessment": {
+            "images": {
               "enabled": false,
               "stepStatus": {},
             },
-            "imageAssessment": {
-              "enabled": false,
-              "stepStatus": {},
-            },
-            "keyboardInteractionAssessment": {
+            "keyboardInteraction": {
               "enabled": false,
               "stepStatus": {},
             },
@@ -425,15 +421,19 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "enabled": false,
               "stepStatus": {},
             },
-            "nativeWidgetsAssessment": {
+            "nativeWidgets": {
               "enabled": false,
               "stepStatus": {},
             },
-            "repetitiveContentAssessment": {
+            "repetitiveContent": {
               "enabled": false,
               "stepStatus": {},
             },
-            "visibleFocusOrderAssessment": {
+            "textLegibility": {
+              "enabled": false,
+              "stepStatus": {},
+            },
+            "visibleFocusOrder": {
               "enabled": false,
               "stepStatus": {},
             },

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -219,7 +219,6 @@ describe('AssessmentBuilderTest', () => {
                 requirement5,
                 requirement6,
             ],
-            storeDataKey: 'headingsAssessment',
             visualizationConfiguration: {},
             getTestViewContainer: getTestViewContainerStub,
         };
@@ -348,7 +347,6 @@ describe('AssessmentBuilderTest', () => {
             title: 'manual assessment title',
             gettingStarted: <span>getting started</span>,
             requirements: [],
-            storeDataKey: 'headingsAssessment',
             visualizationConfiguration: {},
         };
 

--- a/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
+++ b/src/tests/unit/tests/common/configs/web-visualization-configuration-factory.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+import { HeadingsAssessment } from 'assessments/headings/assessment';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import { Requirement } from 'assessments/types/requirement';
@@ -67,7 +68,7 @@ describe('WebVisualizationConfigurationFactory', () => {
     test('getStoreData for headingsAssessment', () => {
         const visualizationType = VisualizationType.HeadingsAssessment;
         const getExpectedData: (data: TestsEnabledState) => ScanData = data =>
-            data.assessments.headingsAssessment;
+            data.assessments[HeadingsAssessment.key];
 
         testGetStoreData(visualizationType, getExpectedData);
     });

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -115,7 +115,7 @@ describe('SelectorMapHelperTest', () => {
 
     assessmentVisualizationTypes.forEach(visualizationType => {
         test(`getState: ${VisualizationType[visualizationType]}`, () => {
-            const stepKey = AutomatedChecks.key;
+            const testKey = AutomatedChecks.key;
             const selectorMap = {
                 key1: { target: ['element1'] } as AssessmentVisualizationInstance,
             };
@@ -130,19 +130,14 @@ describe('SelectorMapHelperTest', () => {
                 featureFlagStoreData: { [FeatureFlags.automatedChecks]: true },
             } as unknown as VisualizationRelatedStoreData;
 
-            setupVisualizationConfigurationFactory(
-                null,
-                null,
-                visualizationType,
-                'automatedChecks',
-            );
+            setupVisualizationConfigurationFactory(null, null, visualizationType, testKey);
             getElementBasedViewModelMock
                 .setup(gebvm =>
                     gebvm(assessmentStoreDataStub, assessmentCardSelectionStoreDataStub),
                 )
                 .returns(() => selectorMap);
 
-            expect(testSubject.getSelectorMap(visualizationType, stepKey, storeData)).toEqual(
+            expect(testSubject.getSelectorMap(visualizationType, null, storeData)).toEqual(
                 selectorMap,
             );
         });


### PR DESCRIPTION
#### Details

This removes the storeDataKey properties from the assessment objects. This is because we want the visualization configuration objects to be consistent with the assessment objects.

##### Motivation

Feature work.

##### Context

There's a lot of context to this, so here's a summary:

First off, reasoning.

The assessment object has two keys before this PR: the `storeDataKey` and the `key`. When an assessment provider looks up a key, it looks for the `key` property. This is used to store data in the `AssessmentStoreData`, which is persisted and utilized for backwards compatibility. The `storeDataKey` is not directly used from the assessment object but instead is transferred to the visualization configuration object as the `key` property and later utilized to store data within the `VisualizationStore` which is only persisted for MV3 reasons.

There is no tangible benefit that can be seen that was gained from utilizing two different keys here. However, we do run into issues with this current way of operation. The visualization configuration factory will return an object that's `key` will align with the `assessmentObject.storeDataKey` while the assessment providers will instead return an object which will return an object with `key` aligning to `assessmentObject.key`. This can cause confusion as we treat both visualization configuration objects and assessment providers as the source of truth/a way to identify tests. While we can continue to use two different keys (by adding a new `someOtherKey` property to VisualizationConfiguration objects), in this PR, I'm removing them because there doesn't seem to be a clear benefit to doing so while it increases confusion within the codebase.

So, we are now using the assessment object `key` property as the **true** key. This makes sense because that is the key utilized in assessment store data and is persisted/backwards compatible.

The visualization store uses the `storeDataKey` but is only persisted per tab. I did make sure to test the scenario where I started an assessment without these changes and then updated the extension with these changes: the extension worked as expected and did not cause an error (because the store state is permissive: i.e. the new state for that tab had both types of keys and used the new key for changes/state).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
