### PR TITLE
feat(automated-checks): populate scan node results data with assessment data

### DIFF
--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -15,6 +15,7 @@ import {
     DecoratedAxeNodeResult,
     HtmlElementAxeResults,
 } from 'common/types/store-data/visualization-scan-result-data';
+import { getFixResolution, ResolutionCreatorData } from 'injected/adapters/resolution-creator';
 import { forOwn, isEmpty } from 'lodash';
 import { Target } from 'scanner/iruleresults';
 import { DictionaryStringTo } from 'types/common-types';
@@ -195,6 +196,13 @@ export class AssessmentDataConverter {
             isVisualizationSupported: isVisualizationSupported(ruleResult),
             isVisualizationEnabled: false,
             isVisible: true,
+            description: ruleResult.help,
+            url: ruleResult.helpUrl,
+            guidance: ruleResult.guidanceLinks,
+            resolution: getFixResolution({
+                nodeResult: ruleResult,
+                ruleId: ruleResult.id,
+            } as ResolutionCreatorData),
         };
     }
 

--- a/src/common/store-data-to-scan-node-result-converter.ts
+++ b/src/common/store-data-to-scan-node-result-converter.ts
@@ -18,6 +18,7 @@ import {
 } from 'common/types/store-data/unified-data-interface';
 import { IssueFilingUrlStringUtils } from 'issue-filing/common/issue-filing-url-string-utils';
 import { find, forOwn } from 'lodash';
+import { Target } from 'scanner/iruleresults';
 
 export type ScanNodeResult = UnifiedResult & {
     rule: UnifiedRule;
@@ -115,6 +116,7 @@ export function convertAssessmentStoreDataToScanNodeResults(
                         instance,
                         requirementIdentifier,
                         cardSelectionStoreData,
+                        instance.target,
                     );
                     allResults.push(node);
                 },
@@ -131,6 +133,7 @@ function convertAssessmentResultToScanNodeResult(
     instance: GeneratedAssessmentInstance,
     requirementIdentifier: string,
     cardSelectionViewDataForTest: CardSelectionStoreData,
+    target: Target,
 ): ScanNodeResult {
     const instanceId = testStepResult.id;
     const status = convertTestStepResultStatusToCardResultStatus(testStepResult.status);
@@ -144,14 +147,22 @@ function convertAssessmentResultToScanNodeResult(
         identifiers: {
             conciseName: IssueFilingUrlStringUtils.getSelectorLastPart(selector),
             identifier: selector,
+            target,
+            'css-selector': selector,
         },
         descriptors: {
             snippet: instance.html,
         },
         resolution: {
+            ...testStepResult.resolution,
             howToFixSummary: testStepResult.failureSummary,
         },
-        rule: { id: requirementIdentifier },
+        rule: {
+            id: requirementIdentifier,
+            description: testStepResult.description,
+            url: testStepResult.url,
+            guidance: testStepResult.guidance,
+        },
     };
     return node;
 }

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -4,6 +4,7 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { Target } from 'scanner/iruleresults';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { VisualizationType } from '../visualization-type';
+import { GuidanceLink } from './guidance-links';
 import { Tab } from './itab';
 import { ManualTestStatus, ManualTestStatusData } from './manual-test-status';
 
@@ -66,6 +67,10 @@ export interface TestStepResult {
     isVisualizationEnabled: boolean;
     isVisible: boolean;
     originalStatus?: ManualTestStatus;
+    description?: string;
+    url?: string;
+    guidance?: GuidanceLink[];
+    resolution?: DictionaryStringTo<any>;
 }
 
 export interface AssessmentNavState {

--- a/src/injected/adapters/resolution-creator.ts
+++ b/src/injected/adapters/resolution-creator.ts
@@ -19,9 +19,9 @@ export interface ResolutionCreatorData {
 export const getFixResolution: ResolutionCreator = (data: ResolutionCreatorData) => {
     return {
         'how-to-fix-web': {
-            any: data.nodeResult.any.map(checkResult => checkResult.message),
-            none: data.nodeResult.none.map(checkResult => checkResult.message),
-            all: data.nodeResult.all.map(checkResult => checkResult.message),
+            any: data.nodeResult.any?.map(checkResult => checkResult.message),
+            none: data.nodeResult.none?.map(checkResult => checkResult.message),
+            all: data.nodeResult.all?.map(checkResult => checkResult.message),
         },
     };
 };

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -6,6 +6,7 @@ import { isResultHighlightUnavailableWeb } from 'common/is-result-highlight-unav
 import { Logger } from 'common/logging/logger';
 import { StoreUpdateMessageHub } from 'common/store-update-message-hub';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import { AssessmentCardSelectionStoreData } from 'common/types/store-data/assessment-card-selection-store-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { NeedsReviewCardSelectionStoreData } from 'common/types/store-data/needs-review-card-selection-store-data';
 import { NeedsReviewScanResultStoreData } from 'common/types/store-data/needs-review-scan-result-data';
@@ -85,7 +86,9 @@ export class MainWindowInitializer extends WindowInitializer {
     private storeUpdateMessageHub: StoreUpdateMessageHub;
     private visualizationStoreProxy: StoreProxy<VisualizationStoreData>;
     private assessmentStoreProxy: StoreProxy<AssessmentStoreData>;
+    private assessmentCardSelectionStoreProxy: StoreProxy<AssessmentCardSelectionStoreData>;
     private quickAssessStoreProxy: StoreProxy<AssessmentStoreData>;
+    private quickAssessCardSelectionStoreProxy: StoreProxy<AssessmentCardSelectionStoreData>;
     private featureFlagStoreProxy: StoreProxy<FeatureFlagStoreData>;
     private userConfigStoreProxy: StoreProxy<UserConfigurationStoreData>;
     private inspectStoreProxy: StoreProxy<InspectStoreData>;
@@ -133,8 +136,16 @@ export class MainWindowInitializer extends WindowInitializer {
             StoreNames[StoreNames.AssessmentStore],
             this.storeUpdateMessageHub,
         );
+        this.assessmentCardSelectionStoreProxy = new StoreProxy<AssessmentCardSelectionStoreData>(
+            StoreNames[StoreNames.AssessmentCardSelectionStore],
+            this.storeUpdateMessageHub,
+        );
         this.quickAssessStoreProxy = new StoreProxy<AssessmentStoreData>(
             StoreNames[StoreNames.QuickAssessStore],
+            this.storeUpdateMessageHub,
+        );
+        this.quickAssessCardSelectionStoreProxy = new StoreProxy<AssessmentCardSelectionStoreData>(
+            StoreNames[StoreNames.QuickAssessCardSelectionStore],
             this.storeUpdateMessageHub,
         );
         this.tabStoreProxy = new StoreProxy<TabStoreData>(
@@ -239,6 +250,7 @@ export class MainWindowInitializer extends WindowInitializer {
             this.visualizationScanResultStoreProxy,
             this.featureFlagStoreProxy,
             this.assessmentStoreProxy,
+            this.assessmentCardSelectionStoreProxy,
             this.userConfigStoreProxy,
             this.unifiedScanResultStoreProxy,
             this.cardSelectionStoreProxy,
@@ -246,6 +258,7 @@ export class MainWindowInitializer extends WindowInitializer {
             this.needsReviewCardSelectionStoreProxy,
             this.permissionsStateStoreProxy,
             this.quickAssessStoreProxy,
+            this.quickAssessCardSelectionStoreProxy,
         ]);
 
         const clientStoreListener = new ClientStoreListener(storeHub);

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -75,7 +75,10 @@ export class SelectorMapHelper {
         const assessmentConfig =
             this.visualizationConfigurationFactory.getConfiguration(visualizationType);
         if (featureFlagStoreData[FeatureFlags.automatedChecks]) {
-            if (assessmentConfig.key === AutomatedChecks.getVisualizationConfiguration().key) {
+            if (
+                assessmentConfig.key === AutomatedChecks.getVisualizationConfiguration().key &&
+                assessmentCardSelectionStoreData
+            ) {
                 const assessmentScanNodeResults = this.convertAssessmentDataToScanNodeResults(
                     assessmentStoreData,
                     assessmentConfig.key,

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -121,6 +121,10 @@ describe('AssessmentDataConverter', () => {
                             html: htmlStub,
                             id: 'id1',
                             status: false,
+                            help: 'help-text',
+                            guidanceLinks: [],
+                            helpUrl: 'help-url',
+                            all: [{ message: 'how-to-fix' }],
                         } as DecoratedAxeNodeResult,
                     },
                     target: [selectorStub],
@@ -140,6 +144,16 @@ describe('AssessmentDataConverter', () => {
                             isVisible: true,
                             isVisualizationEnabled: false,
                             isVisualizationSupported: true,
+                            description: 'help-text',
+                            url: 'help-url',
+                            guidance: [],
+                            resolution: {
+                                'how-to-fix-web': {
+                                    all: ['how-to-fix'],
+                                    any: undefined,
+                                    none: undefined,
+                                },
+                            },
                         },
                     },
                 },
@@ -284,6 +298,7 @@ describe('AssessmentDataConverter', () => {
                                 {
                                     id: 'rule1',
                                     data: { someProperty: 1 },
+                                    message: 'how-to-fix',
                                 },
                             ],
                             html: htmlStub,
@@ -326,6 +341,16 @@ describe('AssessmentDataConverter', () => {
                             isVisible: true,
                             isVisualizationEnabled: false,
                             isVisualizationSupported: true,
+                            description: undefined,
+                            guidance: undefined,
+                            url: undefined,
+                            resolution: {
+                                'how-to-fix-web': {
+                                    all: undefined,
+                                    any: ['how-to-fix'],
+                                    none: undefined,
+                                },
+                            },
                         },
                         [anotherTestStep]: {
                             id: 'id2',

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -23,7 +23,7 @@ import {
     exampleAssessmentResult,
     exampleUnifiedResult,
 } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
-
+// TODO
 describe('StoreDataToScanNodeResultConverter', () => {
     describe('convertUnifiedStoreDataToScanNodeResults', () => {
         test('store data is empty returns null', () => {
@@ -110,10 +110,20 @@ describe('StoreDataToScanNodeResultConverter', () => {
             const expectedResult = [
                 {
                     descriptors: { snippet: selector },
-                    identifiers: { conciseName: selector, identifier: selector },
+                    identifiers: {
+                        conciseName: selector,
+                        identifier: selector,
+                        'css-selector': selector,
+                        target: [selector],
+                    },
                     isSelected: false,
                     resolution: { howToFixSummary: testStepResult.failureSummary },
-                    rule: { id: ruleId },
+                    rule: {
+                        id: ruleId,
+                        description: undefined,
+                        guidance: undefined,
+                        url: undefined,
+                    },
                     ruleId: ruleId,
                     status: 'fail',
                     uid: testStepResult.id,
@@ -142,10 +152,20 @@ describe('StoreDataToScanNodeResultConverter', () => {
             const expectedResult = [
                 {
                     descriptors: { snippet: selector },
-                    identifiers: { conciseName: selector, identifier: selector },
+                    identifiers: {
+                        conciseName: selector,
+                        identifier: selector,
+                        'css-selector': selector,
+                        target: [selector],
+                    },
                     isSelected: true,
                     resolution: { howToFixSummary: testStepResult.failureSummary },
-                    rule: { id: ruleId },
+                    rule: {
+                        id: ruleId,
+                        description: undefined,
+                        guidance: undefined,
+                        url: undefined,
+                    },
                     ruleId: ruleId,
                     status: 'fail',
                     uid: testStepResult.id,
@@ -185,20 +205,40 @@ describe('StoreDataToScanNodeResultConverter', () => {
             const expectedResult = [
                 {
                     descriptors: { snippet: selector },
-                    identifiers: { conciseName: selector, identifier: selector },
+                    identifiers: {
+                        conciseName: selector,
+                        identifier: selector,
+                        'css-selector': selector,
+                        target: [selector],
+                    },
                     isSelected: false,
                     resolution: { howToFixSummary: testStepResult1.failureSummary },
-                    rule: { id: ruleId1 },
+                    rule: {
+                        id: ruleId1,
+                        description: undefined,
+                        guidance: undefined,
+                        url: undefined,
+                    },
                     ruleId: ruleId1,
                     status: 'fail',
                     uid: testStepResult1.id,
                 },
                 {
                     descriptors: { snippet: selector },
-                    identifiers: { conciseName: selector, identifier: selector },
+                    identifiers: {
+                        conciseName: selector,
+                        identifier: selector,
+                        'css-selector': selector,
+                        target: [selector],
+                    },
                     isSelected: false,
                     resolution: { howToFixSummary: testStepResult2.failureSummary },
-                    rule: { id: ruleId2 },
+                    rule: {
+                        id: ruleId2,
+                        description: undefined,
+                        guidance: undefined,
+                        url: undefined,
+                    },
                     ruleId: ruleId2,
                     status: 'fail',
                     uid: testStepResult2.id,
@@ -240,20 +280,40 @@ describe('StoreDataToScanNodeResultConverter', () => {
             const expectedResult = [
                 {
                     descriptors: { snippet: selector1 },
-                    identifiers: { conciseName: selector1, identifier: selector1 },
+                    identifiers: {
+                        conciseName: selector1,
+                        identifier: selector1,
+                        'css-selector': selector1,
+                        target: [selector1],
+                    },
                     isSelected: false,
                     resolution: { howToFixSummary: testStepResult1.failureSummary },
-                    rule: { id: ruleId1 },
+                    rule: {
+                        id: ruleId1,
+                        description: undefined,
+                        guidance: undefined,
+                        url: undefined,
+                    },
                     ruleId: ruleId1,
                     status: 'fail',
                     uid: testStepResult1.id,
                 },
                 {
                     descriptors: { snippet: selector2 },
-                    identifiers: { conciseName: selector2, identifier: selector2 },
+                    identifiers: {
+                        conciseName: selector2,
+                        identifier: selector2,
+                        'css-selector': selector2,
+                        target: [selector2],
+                    },
                     isSelected: false,
                     resolution: { howToFixSummary: testStepResult2.failureSummary },
-                    rule: { id: ruleId2 },
+                    rule: {
+                        id: ruleId2,
+                        description: undefined,
+                        guidance: undefined,
+                        url: undefined,
+                    },
                     ruleId: ruleId2,
                     status: 'fail',
                     uid: testStepResult2.id,

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -23,7 +23,7 @@ import {
     exampleAssessmentResult,
     exampleUnifiedResult,
 } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
-// TODO
+
 describe('StoreDataToScanNodeResultConverter', () => {
     describe('convertUnifiedStoreDataToScanNodeResults', () => {
         test('store data is empty returns null', () => {

--- a/src/tests/unit/tests/injected/adapters/resolution-creator.test.ts
+++ b/src/tests/unit/tests/injected/adapters/resolution-creator.test.ts
@@ -8,6 +8,28 @@ import {
 } from 'injected/adapters/resolution-creator';
 
 describe('ResolutionCreator', () => {
+    it('outputs correct fix resolution with undefined properties', () => {
+        const resolutionCreatorDataStub: ResolutionCreatorData = {
+            ruleId: 'rule id',
+            nodeResult: {
+                any: undefined,
+                all: undefined,
+                none: undefined,
+            },
+        };
+
+        const expected = {
+            'how-to-fix-web': {
+                any: undefined,
+                none: undefined,
+                all: undefined,
+            },
+        };
+
+        const actual = getFixResolution(resolutionCreatorDataStub);
+        expect(actual).toEqual(expected);
+    });
+
     it('outputs correct fix resolution with no data', () => {
         const resolutionCreatorDataStub: ResolutionCreatorData = {
             ruleId: 'rule id',


### PR DESCRIPTION
#### Details

Prior to these changes, assessment data and was missing some of the metadata that unified data has about rules and rule failures. This meant that the the details view cards for the new assessment automated checks would be missing a lot of the information that the fastpass automated checks cards include (for example, how to fix text and rule descriptions). This PR adds the wiring to pass the relevant data through to the new assessment automated checks view. 

##### Motivation

Feature work

##### Context

This PR also includes two small bug fixes discovered while debugging the new assessment automated checks. These can be separated into separate PRs if needed, but they're so small I figured the might as well be lumped together:

- In `main-window-initializer.ts` the new assessment and quick assess card selection stores were not being properly created and initialized. This PR adds that logic.
- In `selector-map-helper.ts` there are cases where the `assessmentCardSelectionStoreData` data is undefined, causing errors. This PR adds a check to ensure we don't reference it when it's undefined. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
