### PR TITLE
build: fix unified unsigned build issues with yarn v3 migration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -587,6 +587,17 @@ module.exports = function (grunt) {
                     '-c',
                     configFile,
                 ],
+                opts: {
+                    env: {
+                        ...process.env,
+                        // electron-builder performs an internal yarn install step to install
+                        // production dependencies for the specific platform being built. This
+                        // will (correctly) result in a different yarn.lock file than our normal
+                        // one. Yarn will throw an error for yarn.lock differences on CI agents;
+                        // unsetting this environment variable suppresses that behavior.
+                        CI: undefined,
+                    },
+                },
             },
             (error, result, code) => {
                 if (error) {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "test:e2e:docker:run:web": "docker run -t accessibility-insights-web-e2e",
         "test:e2e:docker:run:unified": "docker run -t accessibility-insights-unified-e2e sh -c \"yarn test:unified --ci\"",
         "test:e2e:docker": "npm-run-all --serial test:e2e:docker:build \"test:e2e:docker:run {@}\" --",
-        "test:unified": "cross-env NODE_OPTIONS='--unhandled-rejections=strict' jest --projects src/tests/electron --runInBand --forceExit --detectOpenHandles",
+        "test:unified": "cross-env NODE_OPTIONS='--unhandled-rejections=strict --max-old-space-size=1536' jest --projects src/tests/electron --runInBand --forceExit --detectOpenHandles",
         "test:report:e2e": "yarn packages --include accessibility-insights-report-e2e-tests run test",
         "tbuild": "yarn build && yarn type:check",
         "tbuild:all": "yarn build:all && yarn type:check",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "test:e2e:docker:run:web": "docker run -t accessibility-insights-web-e2e",
         "test:e2e:docker:run:unified": "docker run -t accessibility-insights-unified-e2e sh -c \"yarn test:unified --ci\"",
         "test:e2e:docker": "npm-run-all --serial test:e2e:docker:build \"test:e2e:docker:run {@}\" --",
-        "test:unified": "cross-env NODE_OPTIONS='--unhandled-rejections=strict --max-old-space-size=1536' jest --projects src/tests/electron --runInBand --forceExit --detectOpenHandles",
+        "test:unified": "cross-env NODE_OPTIONS='--unhandled-rejections=strict --max-old-space-size=512' jest --projects src/tests/electron --runInBand --forceExit --detectOpenHandles",
         "test:report:e2e": "yarn packages --include accessibility-insights-report-e2e-tests run test",
         "tbuild": "yarn build && yarn type:check",
         "tbuild:all": "yarn build:all && yarn type:check",


### PR DESCRIPTION
#### Details

This PR attempts to fix two issues with our unified unsigned build that started occurring with the yarn v3 update:

* Mac and Windows agents were hitting out-of-heap errors during the test:unified step. This PR adds `--max-old-space-size=512` to that command to attempt to mitigate this.
* Linux agents were hitting an error during `build:unified:all` where Yarn would complain about being forced to update a lockfile as part of an `electron-builder` step. Implemented a workaround for this and a big comment explaining it in `Gruntfile.js`.

##### Motivation

Fix unified unsigned build

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
