### PR TITLE
feat(automated-checks): selector map helper only returns failures for automated checks in assessment/quick assess

### DIFF
--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -84,8 +84,11 @@ export class SelectorMapHelper {
                     assessmentConfig.key,
                     assessmentCardSelectionStoreData[assessmentConfig.key],
                 );
+                const failureScanNodeResults = assessmentScanNodeResults.filter(
+                    result => result.status === 'fail',
+                );
                 return this.getElementBasedViewModel(
-                    assessmentScanNodeResults,
+                    failureScanNodeResults,
                     assessmentCardSelectionStoreData[assessmentConfig.key],
                 );
             }

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -7,6 +7,7 @@ import { FeatureFlags } from 'common/feature-flags';
 import {
     ConvertAssessmentStoreDataToScanNodeResultsCallback,
     ConvertUnifiedStoreDataToScanNodeResultsCallback,
+    ScanNodeResult,
 } from 'common/store-data-to-scan-node-result-converter';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ManualTestStatus } from 'common/types/store-data/manual-test-status';
@@ -52,7 +53,7 @@ describe('SelectorMapHelperTest', () => {
         VisualizationType.NeedsReview,
     ];
 
-    const assessmentVisualizationTypes = [VisualizationType.AutomatedChecks];
+    const assessmentTestsUsingElementBasedViewModels = [VisualizationType.AutomatedChecks];
 
     beforeEach(() => {
         visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
@@ -135,7 +136,7 @@ describe('SelectorMapHelperTest', () => {
         });
     });
 
-    assessmentVisualizationTypes.forEach(visualizationType => {
+    assessmentTestsUsingElementBasedViewModels.forEach(visualizationType => {
         test(`getState: ${VisualizationType[visualizationType]}`, () => {
             const testKey = AutomatedChecks.key;
             const selectorMap = {
@@ -153,14 +154,20 @@ describe('SelectorMapHelperTest', () => {
             } as unknown as VisualizationRelatedStoreData;
 
             setupVisualizationConfigurationFactory(null, null, visualizationType, testKey);
-            const scanResultsNodesStub = [];
+            const scanResultsNodesStub = [
+                { uid: 'failing-result-id', status: 'fail' },
+                { uid: 'non-failing-result-id', status: 'pass' },
+            ] as ScanNodeResult[];
+            const failingScanResultsNodes = [scanResultsNodesStub[0]];
             convertAssessmentStoreDataForScanNodeResultsCallbackMock
                 .setup(m =>
                     m(assessmentStoreDataStub, testKey, assessmentCardSelectionStoreDataStub),
                 )
                 .returns(() => scanResultsNodesStub);
             getElementBasedViewModelMock
-                .setup(gebvm => gebvm(scanResultsNodesStub, assessmentCardSelectionStoreDataStub))
+                .setup(gebvm =>
+                    gebvm(failingScanResultsNodes, assessmentCardSelectionStoreDataStub),
+                )
                 .returns(() => selectorMap);
 
             expect(testSubject.getSelectorMap(visualizationType, null, storeData)).toEqual(


### PR DESCRIPTION
#### Details

We only scan/gather failures in automated checks in fastpass but in assessment/quick assess we gather passing instances as well (shown as 'no failing instances' in the report vs. 'no matching instances'). As such, the selector map helper filters those out for visualization purposes.

##### Motivation

Feature work.

##### Context

Selector map helper could/should definitely be refactored such that the methods live off visualization configurations but felt that may be too large a change for now.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
