### PR TITLE
fix(automated-checks): remove target page changed view in assessment automated checks

### DIFF
--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -74,7 +74,7 @@ function createTargetPageChangedView(props: AdhocIssuesTestViewProps): JSX.Eleme
     );
 }
 
-export function createTestView(props: AdhocIssuesTestViewProps): JSX.Element {
+function createTestView(props: AdhocIssuesTestViewProps): JSX.Element {
     return (
         <>
             <BannerWarnings

--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -74,7 +74,7 @@ function createTargetPageChangedView(props: AdhocIssuesTestViewProps): JSX.Eleme
     );
 }
 
-function createTestView(props: AdhocIssuesTestViewProps): JSX.Element {
+export function createTestView(props: AdhocIssuesTestViewProps): JSX.Element {
     return (
         <>
             <BannerWarnings

--- a/src/DetailsView/components/assessment-issues-test-view.tsx
+++ b/src/DetailsView/components/assessment-issues-test-view.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    AdhocIssuesTestViewProps,
+    createTestView,
+} from 'DetailsView/components/adhoc-issues-test-view';
+import styles from 'DetailsView/components/adhoc-issues-test-view.scss';
+import * as React from 'react';
+import { NamedFC } from '../../common/react/named-fc';
+
+export type AssessmentIssuesTestViewProps = AdhocIssuesTestViewProps;
+
+export const AssessmentIssuesTestView = NamedFC<AssessmentIssuesTestViewProps>(
+    'AssessmentIssuesTestView',
+    props => {
+        const view = createTestView(props);
+
+        return <div className={styles.issuesTestView}>{view}</div>;
+    },
+);

--- a/src/DetailsView/components/assessment-issues-test-view.tsx
+++ b/src/DetailsView/components/assessment-issues-test-view.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    AdhocIssuesTestViewProps,
-    createTestView,
-} from 'DetailsView/components/adhoc-issues-test-view';
+import { AdhocIssuesTestViewProps } from 'DetailsView/components/adhoc-issues-test-view';
 import styles from 'DetailsView/components/adhoc-issues-test-view.scss';
+import { BannerWarnings } from 'DetailsView/components/banner-warnings';
+import { DetailsListIssuesView } from 'DetailsView/components/details-list-issues-view';
 import * as React from 'react';
 import { NamedFC } from '../../common/react/named-fc';
 
@@ -18,3 +17,18 @@ export const AssessmentIssuesTestView = NamedFC<AssessmentIssuesTestViewProps>(
         return <div className={styles.issuesTestView}>{view}</div>;
     },
 );
+
+function createTestView(props: AssessmentIssuesTestViewProps): JSX.Element {
+    return (
+        <>
+            <BannerWarnings
+                deps={props.deps}
+                warnings={props.scanIncompleteWarnings}
+                warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
+                test={props.selectedTest}
+                visualizationStoreData={props.visualizationStoreData}
+            />
+            <DetailsListIssuesView {...props} />
+        </>
+    );
+}

--- a/src/DetailsView/components/default-test-view-container-provider.tsx
+++ b/src/DetailsView/components/default-test-view-container-provider.tsx
@@ -5,6 +5,7 @@ import { NeedsReviewInstancesSection } from 'common/components/cards/needs-revie
 import { AdhocIssuesTestView } from 'DetailsView/components/adhoc-issues-test-view';
 import { AdhocStaticTestView } from 'DetailsView/components/adhoc-static-test-view';
 import { AdhocTabStopsTestView } from 'DetailsView/components/adhoc-tab-stops-test-view';
+import { AssessmentIssuesTestView } from 'DetailsView/components/assessment-issues-test-view';
 import { AssessmentTestView } from 'DetailsView/components/assessment-test-view';
 import {
     TestViewContainerProvider,
@@ -49,7 +50,7 @@ export class DefaultTestViewContainerProvider implements TestViewContainerProvid
         props: TestViewContainerProviderProps,
     ): JSX.Element {
         return (
-            <AdhocIssuesTestView
+            <AssessmentIssuesTestView
                 instancesSection={FailedInstancesSection}
                 cardSelectionMessageCreator={props.assessmentCardSelectionMessageCreator}
                 cardsViewData={props.assessmentCardsViewData}

--- a/src/DetailsView/components/test-view-container-provider.tsx
+++ b/src/DetailsView/components/test-view-container-provider.tsx
@@ -5,6 +5,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { AdhocIssuesTestViewProps } from 'DetailsView/components/adhoc-issues-test-view';
 import { AdhocStaticTestViewProps } from 'DetailsView/components/adhoc-static-test-view';
 import { AdhocTabStopsTestViewProps } from 'DetailsView/components/adhoc-tab-stops-test-view';
+import { AssessmentIssuesTestViewProps } from 'DetailsView/components/assessment-issues-test-view';
 import { AssessmentTestViewProps } from 'DetailsView/components/assessment-test-view';
 
 export type TestViewContainerProviderProps = {
@@ -15,7 +16,7 @@ export type TestViewContainerProviderProps = {
     assessmentCardsViewData: CardsViewModel;
     assessmentCardSelectionMessageCreator: CardSelectionMessageCreator;
 } & Omit<
-    AdhocIssuesTestViewProps,
+    AdhocIssuesTestViewProps | AssessmentIssuesTestViewProps,
     | 'instancesSection'
     | 'cardSelectionMessageCreator'
     | 'cardsViewData'

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-issues-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-issues-test-view.test.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssessmentIssuesTestView should return DetailsListIssuesView 1`] = `
+<div
+  className="issuesTestView"
+>
+  <React.Fragment>
+    <BannerWarnings
+      deps={{}}
+      test={-1}
+      visualizationStoreData={
+        {
+          "scanning": "test-scanning",
+          "tests": {},
+        }
+      }
+      warningConfiguration={{}}
+      warnings={[]}
+    />
+    <DetailsListIssuesView
+      clickHandlerFactory={[typemoq mock object]}
+      configuration={
+        {
+          "displayableData": {
+            "title": "test title",
+          },
+          "getStoreData": [Function],
+        }
+      }
+      deps={{}}
+      instancesSection={[Function]}
+      scanIncompleteWarnings={[]}
+      selectedTest={-1}
+      switcherNavConfiguration={
+        {
+          "warningConfiguration": {},
+        }
+      }
+      tabStoreData={
+        {
+          "isChanged": false,
+        }
+      }
+      visualizationStoreData={
+        {
+          "scanning": "test-scanning",
+          "tests": {},
+        }
+      }
+    />
+  </React.Fragment>
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/default-test-view-container-provider.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/default-test-view-container-provider.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DefaultTestViewContainerProvider can create assessment automated checks test view container 1`] = `
-<AdhocIssuesTestView
+<AssessmentIssuesTestView
   assessmentCardSelectionMessageCreator={{}}
   assessmentCardsViewData={{}}
   automatedChecksCardSelectionMessageCreator={{}}

--- a/src/tests/unit/tests/DetailsView/components/assessment-issues-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-issues-test-view.test.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { CommonInstancesSectionProps } from 'common/components/cards/common-instances-section-props';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { NamedFC } from 'common/react/named-fc';
+import { DisplayableVisualizationTypeData } from 'common/types/displayable-visualization-type-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import {
+    ScanData,
+    TestsEnabledState,
+    VisualizationStoreData,
+} from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import {
+    AssessmentIssuesTestView,
+    AssessmentIssuesTestViewProps,
+} from 'DetailsView/components/assessment-issues-test-view';
+import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
+import { WarningConfiguration } from 'DetailsView/components/warning-configuration';
+import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+
+describe('AssessmentIssuesTestView', () => {
+    const visualizationStoreDataStub = {
+        tests: {},
+        scanning: 'test-scanning',
+    } as VisualizationStoreData;
+
+    const getStoreDataMock: IMock<(data: TestsEnabledState) => ScanData> = Mock.ofInstance(
+        () => null,
+        MockBehavior.Strict,
+    );
+
+    const displayableDataStub = {
+        title: 'test title',
+    } as DisplayableVisualizationTypeData;
+
+    const configuration = {
+        getStoreData: getStoreDataMock.object,
+        displayableData: displayableDataStub,
+    } as VisualizationConfiguration;
+
+    const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
+    const selectedTest: VisualizationType = -1;
+    const warningConfigurationStub: WarningConfiguration = {} as WarningConfiguration;
+    const switcherNavConfigurationStub: DetailsViewSwitcherNavConfiguration = {
+        warningConfiguration: warningConfigurationStub,
+    } as DetailsViewSwitcherNavConfiguration;
+
+    const props = {
+        configuration: configuration,
+        clickHandlerFactory: clickHandlerFactoryMock.object,
+        visualizationStoreData: visualizationStoreDataStub,
+        selectedTest: selectedTest,
+        scanIncompleteWarnings: [],
+        instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
+        switcherNavConfiguration: switcherNavConfigurationStub,
+        deps: {},
+    } as AssessmentIssuesTestViewProps;
+
+    it('should return DetailsListIssuesView', () => {
+        props.tabStoreData = {
+            isChanged: false,
+        } as TabStoreData;
+
+        const actual = shallow(<AssessmentIssuesTestView {...props} />);
+        expect(actual.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Details

Create a new component `AssessmentIssuesTestView` that does not create the target page changed view that is shown in FastPass when refreshing the target page while doing an Assessment. This behavior is consistent with existing Assessment behavior, where refreshing the target page does not affect the ongoing Assessment.

##### Motivation

Fixes behavior in Assessment Automated checks

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
