### PR TITLE
build: attempt 2 to fix CI-specific issue with yarn build:unified:all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,15 @@ jobs:
     - run: yarn build:unified:all
       timeout-minutes: 10
 
+    # This speeds up uploading the artifact by a large margin
+    - name: compress build-results
+      run: tar -zcvf build-results.tar.gz drop
+
     - name: upload artifact build-results
       uses: actions/upload-artifact@v3
       with:
         name: build-results
-        path: drop
+        path: build-results.tar.gz
       timeout-minutes: 5
     
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
     # This speeds up uploading the artifact by a large margin
     - name: compress build-results
       run: tar -zcvf build-results.tar.gz drop
+      timeout-minutes: 5
 
     - name: upload artifact build-results
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,19 +40,11 @@ jobs:
     - run: yarn tbuild:all
       timeout-minutes: 10
 
-    - run: yarn build:unified:all
-      timeout-minutes: 10
-
-    # This speeds up uploading the artifact by a large margin
-    - name: compress build-results
-      run: tar -zcvf build-results.tar.gz drop
-      timeout-minutes: 5
-
     - name: upload artifact build-results
       uses: actions/upload-artifact@v3
       with:
         name: build-results
-        path: build-results.tar.gz
+        path: drop
       timeout-minutes: 5
     
   unit-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
     - run: yarn tbuild:all
       timeout-minutes: 10
 
+    - run: yarn build:unified:all
+      timeout-minutes: 10
+
     - name: upload artifact build-results
       uses: actions/upload-artifact@v3
       with:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -588,14 +588,19 @@ module.exports = function (grunt) {
                     configFile,
                 ],
                 opts: {
+                    // electron-builder performs an internal yarn install step to install
+                    // production dependencies for the specific platform being built. This
+                    // will (correctly) result in a different yarn.lock file than our normal
+                    // one. Yarn will throw an error for yarn.lock differences on CI agents;
+                    // suppressing environment variables prevents it from detecting whether it's
+                    // on a CI agent and suppresses that behavior.
                     env: {
                         ...process.env,
-                        // electron-builder performs an internal yarn install step to install
-                        // production dependencies for the specific platform being built. This
-                        // will (correctly) result in a different yarn.lock file than our normal
-                        // one. Yarn will throw an error for yarn.lock differences on CI agents;
-                        // unsetting this environment variable suppresses that behavior.
+                        // These specific variables are the ones detected by package ci-info
                         CI: undefined,
+                        CONTINUOUS_INTEGRATION: undefined,
+                        GITHUB_ACTIONS: undefined,
+                        SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: undefined,
                     },
                 },
             },


### PR DESCRIPTION
#### Details

This PR is a follow-up to #6530 , which partially resolved the build issues in our ADO CI build, but didn't resolve the issue where `yarn build:unified:all` fails in CI due to yarn complaining about lockfile modifications. The mechanism from #6530 is the right idea, but just unsetting the `CI` variable isn't enough - Yarn uses the `ci-info` package to detect CI environments and it also recognizes a few more specific variables that this PR unsets.

I considered instead just passing an empty environment, instead of `process.env` minus the CI vars. That would be more resilient to changes in which variables `ci-info` detects, but would run the risk of causing more subtle issues if there happens to be any other behavior that electron-builder uses Yarn/Node/etc environment variables to detect; I felt this way was the better tradeoff because if `ci-info` changes and breaks it, it will at least reliably cause a build error, instead of causing who-knows-what subtler effects.

##### Motivation

Resolve failures in unified unsigned build.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
