### PR TITLE
feat(automated-checks): add rule info to scan node results from default rule map

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -9,7 +9,7 @@ import { ScopingActionMessageCreator } from 'common/message-creators/scoping-act
 import { NamedFC } from 'common/react/named-fc';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
 import {
-    convertAssessmentStoreDataToScanNodeResults,
+    ConvertAssessmentStoreDataToScanNodeResultsCallback,
     convertUnifiedStoreDataToScanNodeResults,
 } from 'common/store-data-to-scan-node-result-converter';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
@@ -32,6 +32,7 @@ import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
 import * as React from 'react';
+import { ScannerRuleInfoMap } from 'scanner/scanner-rule-info';
 
 export type DetailsViewContentDeps = {
     getDateFromTimestamp: (timestamp: string) => Date;
@@ -49,6 +50,8 @@ export type DetailsViewContentDeps = {
     isResultHighlightUnavailable: IsResultHighlightUnavailable;
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     testViewContainerProvider: TestViewContainerProvider;
+    defaultRulesMap: ScannerRuleInfoMap;
+    convertAssessmentStoreDataToScanNodeResults: ConvertAssessmentStoreDataToScanNodeResultsCallback;
 } & InteractiveHeaderDeps &
     DetailsViewOverlayDeps &
     DetailsViewBodyDeps;
@@ -155,10 +158,11 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
             props.deps.visualizationConfigurationFactory.getConfiguration(selectedTest).key;
         const selectedCardSelectionStoreData = assessmentCardSelectionStoreData[selectedTestKey];
 
-        const assessmentScanNodeResults = convertAssessmentStoreDataToScanNodeResults(
+        const assessmentScanNodeResults = deps.convertAssessmentStoreDataToScanNodeResults(
             assessmentStoreData,
             selectedTestKey,
             selectedCardSelectionStoreData,
+            deps.defaultRulesMap,
         );
         const assessmentCardsViewData = props.deps.getCardViewData(
             assessmentScanNodeResults,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -39,6 +39,7 @@ import { AutomatedChecksCardSelectionMessageCreator } from 'common/message-creat
 import { NeedsReviewCardSelectionMessageCreator } from 'common/message-creators/needs-review-card-selection-message-creator';
 import { Messages } from 'common/messages';
 import { getNarrowModeThresholdsForWeb } from 'common/narrow-mode-thresholds';
+import { convertAssessmentStoreDataToScanNodeResults } from 'common/store-data-to-scan-node-result-converter';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { ExceptionTelemetryListener } from 'common/telemetry/exception-telemetry-listener';
 import { ExceptionTelemetrySanitizer } from 'common/telemetry/exception-telemetry-sanitizer';
@@ -152,7 +153,7 @@ import { createIssueDetailsBuilder } from '../issue-filing/common/create-issue-d
 import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 import { PlainTextFormatter } from '../issue-filing/common/markup/plain-text-formatter';
 import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
-import { getVersion, scan } from '../scanner/exposed-apis';
+import { getDefaultRulesMap, getVersion, scan } from '../scanner/exposed-apis';
 import { DictionaryStringTo } from '../types/common-types';
 import { IssueFilingServiceProviderImpl } from './../issue-filing/issue-filing-service-provider-impl';
 import { UnifiedResultToIssueFilingDataConverter } from './../issue-filing/unified-result-to-issue-filing-data';
@@ -732,6 +733,8 @@ if (tabId != null) {
                     assessmentFunctionalitySwitcher.getGetAssessmentSummaryModelFromProviderAndStatusData,
                 dataTransferViewController,
                 testViewContainerProvider,
+                defaultRulesMap: getDefaultRulesMap(),
+                convertAssessmentStoreDataToScanNodeResults,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -196,9 +196,6 @@ export class AssessmentDataConverter {
             isVisualizationSupported: isVisualizationSupported(ruleResult),
             isVisualizationEnabled: false,
             isVisible: true,
-            description: ruleResult.help,
-            url: ruleResult.helpUrl,
-            guidance: ruleResult.guidanceLinks,
             resolution: getFixResolution({
                 nodeResult: ruleResult,
                 ruleId: ruleResult.id,

--- a/src/common/store-data-to-scan-node-result-converter.ts
+++ b/src/common/store-data-to-scan-node-result-converter.ts
@@ -18,7 +18,7 @@ import {
 } from 'common/types/store-data/unified-data-interface';
 import { IssueFilingUrlStringUtils } from 'issue-filing/common/issue-filing-url-string-utils';
 import { find, forOwn } from 'lodash';
-import { Target } from 'scanner/iruleresults';
+import { ScannerRuleInfo, ScannerRuleInfoMap } from 'scanner/scanner-rule-info';
 
 export type ScanNodeResult = UnifiedResult & {
     rule: UnifiedRule;
@@ -85,12 +85,14 @@ export type ConvertAssessmentStoreDataToScanNodeResultsCallback = (
     assessmentStoreData: AssessmentStoreData,
     selectedTest: string,
     cardSelectionStoreData: CardSelectionStoreData,
+    ruleInfoMap?: ScannerRuleInfoMap,
 ) => ScanNodeResult[] | null;
 
 export function convertAssessmentStoreDataToScanNodeResults(
     assessmentStoreData: AssessmentStoreData,
     selectedTest: string,
     cardSelectionStoreData: CardSelectionStoreData,
+    ruleInfoMap?: ScannerRuleInfoMap,
 ): ScanNodeResult[] | null {
     if (
         isNullOrUndefined(assessmentStoreData) ||
@@ -116,7 +118,7 @@ export function convertAssessmentStoreDataToScanNodeResults(
                         instance,
                         requirementIdentifier,
                         cardSelectionStoreData,
-                        instance.target,
+                        ruleInfoMap?.[requirementIdentifier],
                     );
                     allResults.push(node);
                 },
@@ -133,7 +135,7 @@ function convertAssessmentResultToScanNodeResult(
     instance: GeneratedAssessmentInstance,
     requirementIdentifier: string,
     cardSelectionViewDataForTest: CardSelectionStoreData,
-    target: Target,
+    ruleInfo: ScannerRuleInfo | undefined,
 ): ScanNodeResult {
     const instanceId = testStepResult.id;
     const status = convertTestStepResultStatusToCardResultStatus(testStepResult.status);
@@ -147,21 +149,20 @@ function convertAssessmentResultToScanNodeResult(
         identifiers: {
             conciseName: IssueFilingUrlStringUtils.getSelectorLastPart(selector),
             identifier: selector,
-            target,
             'css-selector': selector,
+            target: instance.target,
         },
         descriptors: {
             snippet: instance.html,
         },
         resolution: {
             ...testStepResult.resolution,
-            howToFixSummary: testStepResult.failureSummary,
         },
         rule: {
             id: requirementIdentifier,
-            description: testStepResult.description,
-            url: testStepResult.url,
-            guidance: testStepResult.guidance,
+            description: ruleInfo?.help,
+            url: ruleInfo?.url,
+            guidance: ruleInfo?.a11yCriteria,
         },
     };
     return node;

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -4,7 +4,6 @@ import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete
 import { Target } from 'scanner/iruleresults';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { VisualizationType } from '../visualization-type';
-import { GuidanceLink } from './guidance-links';
 import { Tab } from './itab';
 import { ManualTestStatus, ManualTestStatusData } from './manual-test-status';
 
@@ -67,9 +66,6 @@ export interface TestStepResult {
     isVisualizationEnabled: boolean;
     isVisible: boolean;
     originalStatus?: ManualTestStatus;
-    description?: string;
-    url?: string;
-    guidance?: GuidanceLink[];
     resolution?: DictionaryStringTo<any>;
 }
 

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -103,7 +103,7 @@ export type UnifiedRichResolution = {
 };
 
 export type UnifiedResolution = {
-    howToFixSummary: string;
+    howToFixSummary?: string;
     richResolution?: UnifiedRichResolution;
 } & InstancePropertyBag;
 

--- a/src/scanner/exposed-apis.ts
+++ b/src/scanner/exposed-apis.ts
@@ -19,7 +19,7 @@ import { ResultDecorator } from './result-decorator';
 import { RuleProcessor } from './rule-processor';
 import { ScanOptions } from './scan-options';
 import { ScanParameterGenerator } from './scan-parameter-generator';
-import { ScannerRuleInfo } from './scanner-rule-info';
+import { ScannerRuleInfo, ScannerRuleInfoMap } from './scanner-rule-info';
 
 export const scan = (
     options: ScanOptions,
@@ -63,6 +63,15 @@ export const getDefaultRules = (): ScannerRuleInfo[] => {
         ruleIncludedStatus,
         mapAxeTagsToGuidanceLinks,
     );
+};
+
+export const getDefaultRulesMap = (): ScannerRuleInfoMap => {
+    const rules = getDefaultRules();
+    const ruleMap: ScannerRuleInfoMap = {};
+    rules.forEach(rule => {
+        ruleMap[rule.id] = rule;
+    });
+    return ruleMap;
 };
 
 new AxeConfigurator().configureAxe(axe, configuration);

--- a/src/scanner/scanner-rule-info.ts
+++ b/src/scanner/scanner-rule-info.ts
@@ -8,3 +8,7 @@ export interface ScannerRuleInfo {
     url?: string;
     a11yCriteria: HyperlinkDefinition[];
 }
+
+export interface ScannerRuleInfoMap {
+    [ruleId: string]: ScannerRuleInfo;
+}

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -5,6 +5,14 @@ exports[`DetailsViewContent render renders normally 1`] = `
   <InteractiveHeader
     deps={
       {
+        "convertAssessmentStoreDataToScanNodeResults": [Function],
+        "defaultRulesMap": {
+          "some-rule": {
+            "a11yCriteria": null,
+            "help": "some help",
+            "id": "some-rule",
+          },
+        },
         "detailsViewActionMessageCreator": [typemoq mock object],
         "dropdownClickHandler": [typemoq mock object],
         "getAssessmentInstanceTableHandler": [Function],
@@ -37,7 +45,11 @@ exports[`DetailsViewContent render renders normally 1`] = `
     tabClosed={false}
   />
   <DetailsViewBody
-    assessmentCardsViewData={{}}
+    assessmentCardsViewData={
+      {
+        "allCardsCollapsed": true,
+      }
+    }
     assessmentInstanceTableHandler={[typemoq mock object]}
     assessmentStoreData={
       {
@@ -50,7 +62,11 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "resultDescription": "",
       }
     }
-    automatedChecksCardsViewData={{}}
+    automatedChecksCardsViewData={
+      {
+        "allCardsCollapsed": false,
+      }
+    }
     dataTransferViewStoreData={
       {
         "showQuickAssessToAssessmentConfirmDialog": false,
@@ -58,6 +74,14 @@ exports[`DetailsViewContent render renders normally 1`] = `
     }
     deps={
       {
+        "convertAssessmentStoreDataToScanNodeResults": [Function],
+        "defaultRulesMap": {
+          "some-rule": {
+            "a11yCriteria": null,
+            "help": "some help",
+            "id": "some-rule",
+          },
+        },
         "detailsViewActionMessageCreator": [typemoq mock object],
         "dropdownClickHandler": [typemoq mock object],
         "getAssessmentInstanceTableHandler": [Function],
@@ -99,7 +123,11 @@ exports[`DetailsViewContent render renders normally 1`] = `
         "isVirtualKeyboardCollapsed": false,
       }
     }
-    needsReviewCardsViewData={{}}
+    needsReviewCardsViewData={
+      {
+        "allCardsCollapsed": false,
+      }
+    }
     pathSnippetStoreData={
       {
         "path": null,
@@ -448,6 +476,14 @@ exports[`DetailsViewContent render renders normally 1`] = `
   <DetailsViewOverlay
     deps={
       {
+        "convertAssessmentStoreDataToScanNodeResults": [Function],
+        "defaultRulesMap": {
+          "some-rule": {
+            "a11yCriteria": null,
+            "help": "some help",
+            "id": "some-rule",
+          },
+        },
         "detailsViewActionMessageCreator": [typemoq mock object],
         "dropdownClickHandler": [typemoq mock object],
         "getAssessmentInstanceTableHandler": [Function],

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -121,9 +121,6 @@ describe('AssessmentDataConverter', () => {
                             html: htmlStub,
                             id: 'id1',
                             status: false,
-                            help: 'help-text',
-                            guidanceLinks: [],
-                            helpUrl: 'help-url',
                             all: [{ message: 'how-to-fix' }],
                         } as DecoratedAxeNodeResult,
                     },
@@ -144,9 +141,6 @@ describe('AssessmentDataConverter', () => {
                             isVisible: true,
                             isVisualizationEnabled: false,
                             isVisualizationSupported: true,
-                            description: 'help-text',
-                            url: 'help-url',
-                            guidance: [],
                             resolution: {
                                 'how-to-fix-web': {
                                     all: ['how-to-fix'],
@@ -341,9 +335,6 @@ describe('AssessmentDataConverter', () => {
                             isVisible: true,
                             isVisualizationEnabled: false,
                             isVisualizationSupported: true,
-                            description: undefined,
-                            guidance: undefined,
-                            url: undefined,
                             resolution: {
                                 'how-to-fix-web': {
                                     all: undefined,

--- a/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
+++ b/src/tests/unit/tests/common/store-data-to-scan-node-result-converter.test.ts
@@ -19,6 +19,7 @@ import {
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
 import { cloneDeep } from 'lodash';
+import { ScannerRuleInfoMap } from 'scanner/scanner-rule-info';
 import {
     exampleAssessmentResult,
     exampleUnifiedResult,
@@ -117,7 +118,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                         target: [selector],
                     },
                     isSelected: false,
-                    resolution: { howToFixSummary: testStepResult.failureSummary },
+                    resolution: {},
                     rule: {
                         id: ruleId,
                         description: undefined,
@@ -132,6 +133,56 @@ describe('StoreDataToScanNodeResultConverter', () => {
             expect(convertAssessmentStoreDataToScanNodeResults(storeData, testKey, null)).toEqual(
                 expectedResult,
             );
+        });
+
+        test('assessment data with rule info and no card selection store data is converted successfully', () => {
+            const testKey = 'test-key';
+            const assessmentResult = exampleAssessmentResult;
+            const { selector, testStepResult, ruleId } =
+                getAssessmentDataProperties(assessmentResult);
+            const storeData = {
+                assessments: {
+                    'test-key': assessmentResult,
+                },
+                assessmentNavState: { selectedTestType: 'test-key' },
+            } as unknown as AssessmentStoreData;
+            const ruleUrlStub = 'some url';
+            const ruleHelpStub = 'some help';
+            const ruleA11yCriteriaStub = [];
+            const ruleInfoMap: ScannerRuleInfoMap = {
+                [ruleId]: {
+                    id: ruleId,
+                    url: ruleUrlStub,
+                    help: ruleHelpStub,
+                    a11yCriteria: ruleA11yCriteriaStub,
+                },
+            };
+
+            const expectedResult = [
+                {
+                    descriptors: { snippet: selector },
+                    identifiers: {
+                        conciseName: selector,
+                        identifier: selector,
+                        'css-selector': selector,
+                        target: [selector],
+                    },
+                    isSelected: false,
+                    resolution: {},
+                    rule: {
+                        id: ruleId,
+                        description: ruleHelpStub,
+                        guidance: ruleA11yCriteriaStub,
+                        url: ruleUrlStub,
+                    },
+                    ruleId: ruleId,
+                    status: 'fail',
+                    uid: testStepResult.id,
+                },
+            ];
+            expect(
+                convertAssessmentStoreDataToScanNodeResults(storeData, testKey, null, ruleInfoMap),
+            ).toEqual(expectedResult);
         });
 
         test('assessment data with card selection store data is converted successfully', () => {
@@ -159,7 +210,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                         target: [selector],
                     },
                     isSelected: true,
-                    resolution: { howToFixSummary: testStepResult.failureSummary },
+                    resolution: {},
                     rule: {
                         id: ruleId,
                         description: undefined,
@@ -212,7 +263,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                         target: [selector],
                     },
                     isSelected: false,
-                    resolution: { howToFixSummary: testStepResult1.failureSummary },
+                    resolution: {},
                     rule: {
                         id: ruleId1,
                         description: undefined,
@@ -232,7 +283,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                         target: [selector],
                     },
                     isSelected: false,
-                    resolution: { howToFixSummary: testStepResult2.failureSummary },
+                    resolution: {},
                     rule: {
                         id: ruleId2,
                         description: undefined,
@@ -287,7 +338,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                         target: [selector1],
                     },
                     isSelected: false,
-                    resolution: { howToFixSummary: testStepResult1.failureSummary },
+                    resolution: {},
                     rule: {
                         id: ruleId1,
                         description: undefined,
@@ -307,7 +358,7 @@ describe('StoreDataToScanNodeResultConverter', () => {
                         target: [selector2],
                     },
                     isSelected: false,
-                    resolution: { howToFixSummary: testStepResult2.failureSummary },
+                    resolution: {},
                     rule: {
                         id: ruleId2,
                         description: undefined,


### PR DESCRIPTION
#### Details

Uses the default rules to amend rule info to the automated checks. Removes changes to the test step result that was doing this for us because that does not cover the backwards compatibility scenario and would result in a lot of duplicate data.

##### Motivation

Feature work.

##### Context

What if we load an assessment that has a rule that is not included in the default rules? In this case, we simply do not show that info (since we do not have it) in the UI.

A further improvement to this approach would be to start storing rule information onScanCompleted in the AssessmentStore. This could then be used instead to load the data in combination with the default rule information.

Screenshots below of what automated checks looks like when loading an older assessment.
Before:
![image](https://user-images.githubusercontent.com/32555133/227634189-bfd406b2-6c68-4c77-942c-a7630a776343.png)

After:
![image](https://user-images.githubusercontent.com/32555133/227634121-80f624c6-87cc-403c-89e6-bda4d38773e6.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
