### PR TITLE
feat(automated-checks): fix assessment automated checks visualization refresh behavior

### DIFF
--- a/src/DetailsView/components/assessment-issues-test-view.tsx
+++ b/src/DetailsView/components/assessment-issues-test-view.tsx
@@ -1,34 +1,129 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import {
+    AssessmentNavState,
+    AssessmentStoreData,
+} from 'common/types/store-data/assessment-result-data';
 import { AdhocIssuesTestViewProps } from 'DetailsView/components/adhoc-issues-test-view';
 import styles from 'DetailsView/components/adhoc-issues-test-view.scss';
-import { BannerWarnings } from 'DetailsView/components/banner-warnings';
-import { DetailsListIssuesView } from 'DetailsView/components/details-list-issues-view';
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerDeps,
+    AssessmentViewUpdateHandlerProps,
+} from 'DetailsView/components/assessment-view-update-handler';
+import { BannerWarnings, BannerWarningsDeps } from 'DetailsView/components/banner-warnings';
+import {
+    DetailsListIssuesView,
+    DetailsListIssuesViewDeps,
+} from 'DetailsView/components/details-list-issues-view';
+import {
+    TargetChangeDialog,
+    TargetChangeDialogDeps,
+} from 'DetailsView/components/target-change-dialog';
+import { isEqual } from 'lodash';
 import * as React from 'react';
-import { NamedFC } from '../../common/react/named-fc';
 
-export type AssessmentIssuesTestViewProps = AdhocIssuesTestViewProps;
+export type AssessmentIssuesTestViewDeps = {
+    assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
+    getProvider: () => AssessmentsProvider;
+} & BannerWarningsDeps &
+    TargetChangeDialogDeps &
+    AssessmentViewUpdateHandlerDeps &
+    DetailsListIssuesViewDeps;
 
-export const AssessmentIssuesTestView = NamedFC<AssessmentIssuesTestViewProps>(
-    'AssessmentIssuesTestView',
-    props => {
-        const view = createTestView(props);
+export type AssessmentIssuesTestViewProps = {
+    deps: AssessmentIssuesTestViewDeps;
+    assessmentStoreData: AssessmentStoreData;
+} & Omit<AdhocIssuesTestViewProps, 'deps'>;
+
+export class AssessmentIssuesTestView extends React.Component<AssessmentIssuesTestViewProps> {
+    public componentDidMount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onMount(this.getUpdateHandlerProps(this.props));
+    }
+
+    public componentDidUpdate(prevProps: AssessmentIssuesTestViewProps): void {
+        const prevUpdateHandlerProps = this.getUpdateHandlerProps(prevProps);
+        const newUpdateHandlerProps = this.getUpdateHandlerProps(this.props);
+
+        if (isEqual(prevUpdateHandlerProps, newUpdateHandlerProps)) {
+            return;
+        }
+
+        this.props.deps.assessmentViewUpdateHandler.update(
+            this.getUpdateHandlerProps(prevProps),
+            this.getUpdateHandlerProps(this.props),
+        );
+    }
+
+    public componentWillUnmount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onUnmount(
+            this.getUpdateHandlerProps(this.props),
+        );
+    }
+
+    private getUpdateHandlerProps(
+        props: AssessmentIssuesTestViewProps,
+    ): AssessmentViewUpdateHandlerProps {
+        const scanData = props.configuration.getStoreData(props.visualizationStoreData.tests);
+        const selectedRequirementIsEnabled = props.configuration.getTestStatus(
+            scanData,
+            props.assessmentStoreData.assessmentNavState.selectedTestSubview,
+        );
+        const assessmentData = props.configuration.getAssessmentData!(props.assessmentStoreData);
+        const assessment = props.deps
+            .getProvider()
+            .forType(props.assessmentStoreData.assessmentNavState.selectedTestType);
+        const navState = {
+            ...props.assessmentStoreData.assessmentNavState,
+            // since no test subview/requirement is specifically selected in automated checks, we default to first requirement.
+            selectedTestSubview: assessment!.requirements[0].key,
+        } as AssessmentNavState;
+
+        return {
+            deps: props.deps,
+            selectedRequirementIsEnabled: selectedRequirementIsEnabled,
+            assessmentNavState: navState,
+            assessmentData: assessmentData,
+            prevTarget: props.assessmentStoreData.persistedTabInfo,
+            currentTarget: this.getCurrentTarget(),
+        };
+    }
+
+    public render = () => {
+        const view = this.createTestView(this.props);
 
         return <div className={styles.issuesTestView}>{view}</div>;
-    },
-);
+    };
 
-function createTestView(props: AssessmentIssuesTestViewProps): JSX.Element {
-    return (
-        <>
-            <BannerWarnings
-                deps={props.deps}
-                warnings={props.scanIncompleteWarnings}
-                warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
-                test={props.selectedTest}
-                visualizationStoreData={props.visualizationStoreData}
-            />
-            <DetailsListIssuesView {...props} />
-        </>
-    );
+    private getCurrentTarget = () => {
+        return {
+            id: this.props.tabStoreData.id,
+            url: this.props.tabStoreData.url,
+            title: this.props.tabStoreData.title,
+        };
+    };
+
+    private createTestView(props: AssessmentIssuesTestViewProps): JSX.Element {
+        const { deps } = props;
+        const prevTarget = props.assessmentStoreData.persistedTabInfo;
+
+        return (
+            <>
+                <BannerWarnings
+                    deps={props.deps}
+                    warnings={props.scanIncompleteWarnings}
+                    warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
+                    test={props.selectedTest}
+                    visualizationStoreData={props.visualizationStoreData}
+                />
+                <TargetChangeDialog
+                    deps={deps}
+                    prevTab={prevTarget}
+                    newTab={this.getCurrentTarget()}
+                />
+                <DetailsListIssuesView {...props} />
+            </>
+        );
+    }
 }

--- a/src/DetailsView/components/assessment-issues-test-view.tsx
+++ b/src/DetailsView/components/assessment-issues-test-view.tsx
@@ -51,8 +51,8 @@ export class AssessmentIssuesTestView extends React.Component<AssessmentIssuesTe
         }
 
         this.props.deps.assessmentViewUpdateHandler.update(
-            this.getUpdateHandlerProps(prevProps),
-            this.getUpdateHandlerProps(this.props),
+            prevUpdateHandlerProps,
+            newUpdateHandlerProps,
         );
     }
 

--- a/src/DetailsView/components/banner-warnings.tsx
+++ b/src/DetailsView/components/banner-warnings.tsx
@@ -6,11 +6,17 @@ import {
 } from 'DetailsView/components/injection-failed-warning';
 import {
     ScanIncompleteWarning,
+    ScanIncompleteWarningDeps,
     ScanIncompleteWarningProps,
 } from 'DetailsView/components/scan-incomplete-warning';
 import * as React from 'react';
 
-export type BannerWarningsProps = ScanIncompleteWarningProps & InjectionFailedWarningProps;
+export type BannerWarningsDeps = ScanIncompleteWarningDeps;
+
+export type BannerWarningsProps = {
+    deps: BannerWarningsDeps;
+} & Omit<ScanIncompleteWarningProps, 'deps'> &
+    InjectionFailedWarningProps;
 
 export class BannerWarnings extends React.PureComponent<BannerWarningsProps> {
     public render() {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-issues-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-issues-test-view.test.tsx.snap
@@ -1,12 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssessmentIssuesTestView should return DetailsListIssuesView 1`] = `
+exports[`AssessmentIssuesTestView renders 1`] = `
 <div
   className="issuesTestView"
 >
   <React.Fragment>
     <BannerWarnings
-      deps={{}}
+      deps={
+        {
+          "assessmentViewUpdateHandler": [typemoq mock object],
+          "getProvider": [Function],
+        }
+      }
       test={-1}
       visualizationStoreData={
         {
@@ -17,17 +22,49 @@ exports[`AssessmentIssuesTestView should return DetailsListIssuesView 1`] = `
       warningConfiguration={{}}
       warnings={[]}
     />
+    <TargetChangeDialog
+      deps={
+        {
+          "assessmentViewUpdateHandler": [typemoq mock object],
+          "getProvider": [Function],
+        }
+      }
+      newTab={
+        {
+          "id": 0,
+          "title": "test-title",
+          "url": "test-url",
+        }
+      }
+      prevTab={{}}
+    />
     <DetailsListIssuesView
+      assessmentStoreData={
+        {
+          "assessmentNavState": {
+            "selectedTestSubview": "test-subview",
+            "selectedTestType": -1,
+          },
+          "persistedTabInfo": {},
+        }
+      }
       clickHandlerFactory={[typemoq mock object]}
       configuration={
         {
           "displayableData": {
             "title": "test title",
           },
+          "getAssessmentData": [Function],
           "getStoreData": [Function],
+          "getTestStatus": [Function],
         }
       }
-      deps={{}}
+      deps={
+        {
+          "assessmentViewUpdateHandler": [typemoq mock object],
+          "getProvider": [Function],
+        }
+      }
       instancesSection={[Function]}
       scanIncompleteWarnings={[]}
       selectedTest={-1}
@@ -38,7 +75,9 @@ exports[`AssessmentIssuesTestView should return DetailsListIssuesView 1`] = `
       }
       tabStoreData={
         {
-          "isChanged": false,
+          "id": 0,
+          "title": "test-title",
+          "url": "test-url",
         }
       }
       visualizationStoreData={

--- a/src/tests/unit/tests/DetailsView/components/assessment-issues-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-issues-test-view.test.tsx
@@ -1,9 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
 import { CommonInstancesSectionProps } from 'common/components/cards/common-instances-section-props';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { NamedFC } from 'common/react/named-fc';
 import { DisplayableVisualizationTypeData } from 'common/types/displayable-visualization-type-data';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+    PersistedTabInfo,
+} from 'common/types/store-data/assessment-result-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import {
     ScanData,
@@ -15,57 +23,232 @@ import {
     AssessmentIssuesTestView,
     AssessmentIssuesTestViewProps,
 } from 'DetailsView/components/assessment-issues-test-view';
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerProps,
+} from 'DetailsView/components/assessment-view-update-handler';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { WarningConfiguration } from 'DetailsView/components/warning-configuration';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { shallow } from 'enzyme';
+import { cloneDeep } from 'lodash';
 import * as React from 'react';
-import { IMock, Mock, MockBehavior } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('AssessmentIssuesTestView', () => {
-    const visualizationStoreDataStub = {
-        tests: {},
-        scanning: 'test-scanning',
-    } as VisualizationStoreData;
+    let getStoreDataMock: IMock<(data: TestsEnabledState) => ScanData>;
+    let getTestStatusMock: IMock<(data: ScanData, step?: string) => boolean>;
+    let getAssessmentDataMock: IMock<(data: AssessmentStoreData) => AssessmentData>;
+    let configurationStub: VisualizationConfiguration;
+    let clickHandlerFactoryMock: IMock<DetailsViewToggleClickHandlerFactory>;
+    let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
+    let propsStub: AssessmentIssuesTestViewProps;
+    let assessmentProviderMock: IMock<AssessmentsProvider>;
+    let depsStub;
+    let assessmentStoreDataStub;
 
-    const getStoreDataMock: IMock<(data: TestsEnabledState) => ScanData> = Mock.ofInstance(
-        () => null,
-        MockBehavior.Strict,
-    );
-
-    const displayableDataStub = {
-        title: 'test title',
-    } as DisplayableVisualizationTypeData;
-
-    const configuration = {
-        getStoreData: getStoreDataMock.object,
-        displayableData: displayableDataStub,
-    } as VisualizationConfiguration;
-
-    const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
     const selectedTest: VisualizationType = -1;
     const warningConfigurationStub: WarningConfiguration = {} as WarningConfiguration;
     const switcherNavConfigurationStub: DetailsViewSwitcherNavConfiguration = {
         warningConfiguration: warningConfigurationStub,
     } as DetailsViewSwitcherNavConfiguration;
+    const testsStub = {} as TestsEnabledState;
+    const scanDataStub = {} as ScanData;
+    const visualizationStoreDataStub = {
+        tests: testsStub,
+        scanning: 'test-scanning',
+    } as VisualizationStoreData;
+    const displayableDataStub = {
+        title: 'test title',
+    } as DisplayableVisualizationTypeData;
+    const selectedTestViewStub = 'test-subview';
+    const selectedTestTypeStub = -1;
+    const persistedTabInfoStub = {} as PersistedTabInfo;
+    const selectedRequirementIsEnabledStub = true;
+    const assessmentDataStub = {} as AssessmentData;
+    const requirementKeyStub = 'requirement-1';
+    const assessmentStub = { requirements: [{ key: requirementKeyStub }] } as Assessment;
+    const tabStoreDataStub = { id: 0, url: 'test-url', title: 'test-title' } as TabStoreData;
 
-    const props = {
-        configuration: configuration,
-        clickHandlerFactory: clickHandlerFactoryMock.object,
-        visualizationStoreData: visualizationStoreDataStub,
-        selectedTest: selectedTest,
-        scanIncompleteWarnings: [],
-        instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
-        switcherNavConfiguration: switcherNavConfigurationStub,
-        deps: {},
-    } as AssessmentIssuesTestViewProps;
+    beforeEach(() => {
+        assessmentStoreDataStub = {
+            assessmentNavState: {
+                selectedTestSubview: selectedTestViewStub,
+                selectedTestType: selectedTestTypeStub,
+            },
+            persistedTabInfo: persistedTabInfoStub,
+        } as unknown as AssessmentStoreData;
 
-    it('should return DetailsListIssuesView', () => {
-        props.tabStoreData = {
-            isChanged: false,
-        } as TabStoreData;
+        getStoreDataMock = Mock.ofInstance<(data: TestsEnabledState) => ScanData>(
+            (_data: TestsEnabledState) => {
+                return {} as ScanData;
+            },
+            MockBehavior.Strict,
+        );
+        getStoreDataMock
+            .setup(m => m(testsStub))
+            .returns(() => scanDataStub)
+            .verifiable(Times.once());
+        getTestStatusMock = Mock.ofInstance<(data: ScanData, step?: string) => boolean>(
+            (_data: ScanData, _step?: string) => true,
+            MockBehavior.Strict,
+        );
+        getTestStatusMock
+            .setup(m => m(scanDataStub, selectedTestViewStub))
+            .returns(() => selectedRequirementIsEnabledStub)
+            .verifiable(Times.once());
+        getAssessmentDataMock = Mock.ofInstance<(data: AssessmentStoreData) => AssessmentData>(
+            (_data: AssessmentStoreData) => {
+                return {} as AssessmentData;
+            },
+            MockBehavior.Strict,
+        );
+        getAssessmentDataMock
+            .setup(m => m(assessmentStoreDataStub))
+            .returns(() => assessmentDataStub)
+            .verifiable(Times.once());
 
-        const actual = shallow(<AssessmentIssuesTestView {...props} />);
+        configurationStub = {
+            getStoreData: getStoreDataMock.object,
+            getTestStatus: getTestStatusMock.object,
+            getAssessmentData: getAssessmentDataMock.object,
+            displayableData: displayableDataStub,
+        } as VisualizationConfiguration;
+
+        clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
+        updateHandlerMock = Mock.ofType(AssessmentViewUpdateHandler, MockBehavior.Strict);
+        assessmentProviderMock = Mock.ofType(AssessmentsProviderImpl, MockBehavior.Strict);
+        assessmentProviderMock
+            .setup(m => m.forType(selectedTestTypeStub))
+            .returns(() => assessmentStub)
+            .verifiable(Times.once());
+
+        depsStub = {
+            assessmentViewUpdateHandler: updateHandlerMock.object,
+            getProvider: () => assessmentProviderMock.object,
+        };
+
+        propsStub = {
+            configuration: configurationStub,
+            clickHandlerFactory: clickHandlerFactoryMock.object,
+            visualizationStoreData: visualizationStoreDataStub,
+            selectedTest: selectedTest,
+            scanIncompleteWarnings: [],
+            instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
+            switcherNavConfiguration: switcherNavConfigurationStub,
+            assessmentStoreData: assessmentStoreDataStub,
+            tabStoreData: tabStoreDataStub,
+            deps: depsStub,
+        } as AssessmentIssuesTestViewProps;
+    });
+
+    afterEach(() => {
+        getStoreDataMock.verifyAll();
+        getTestStatusMock.verifyAll();
+        clickHandlerFactoryMock.verifyAll();
+        updateHandlerMock.verifyAll();
+        getAssessmentDataMock.verifyAll();
+        assessmentProviderMock.verifyAll();
+    });
+
+    it('renders', () => {
+        updateHandlerMock.setup(u => u.onMount(getUpdateHandlerProps())).verifiable(Times.once());
+
+        const actual = shallow(<AssessmentIssuesTestView {...propsStub} />);
         expect(actual.getElement()).toMatchSnapshot();
     });
+
+    test('componentDidMount', () => {
+        updateHandlerMock.setup(u => u.onMount(getUpdateHandlerProps())).verifiable(Times.once());
+
+        const testObject = new AssessmentIssuesTestView(propsStub);
+
+        testObject.componentDidMount();
+    });
+
+    test('componentWillUnmount', () => {
+        updateHandlerMock.setup(u => u.onUnmount(getUpdateHandlerProps())).verifiable(Times.once());
+
+        const testObject = new AssessmentIssuesTestView(propsStub);
+
+        testObject.componentWillUnmount();
+    });
+
+    test('componentDidUpdate', () => {
+        const newTabStoreDataStub = {
+            id: 1,
+            url: 'test-url-updated',
+            title: 'test-title-updated',
+        } as TabStoreData;
+        const newAssessmentStoreDataStub = {
+            assessmentNavState: {
+                selectedTestSubview: selectedTestViewStub,
+                selectedTestType: selectedTestTypeStub,
+            },
+            persistedTabInfo: newTabStoreDataStub,
+        } as unknown as AssessmentStoreData;
+        const newProps = {
+            configuration: configurationStub,
+            clickHandlerFactory: clickHandlerFactoryMock.object,
+            visualizationStoreData: visualizationStoreDataStub,
+            selectedTest: selectedTest,
+            scanIncompleteWarnings: [],
+            instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
+            switcherNavConfiguration: switcherNavConfigurationStub,
+            assessmentStoreData: newAssessmentStoreDataStub,
+            tabStoreData: tabStoreDataStub,
+            deps: depsStub,
+        } as AssessmentIssuesTestViewProps;
+        const prevProps = propsStub;
+
+        getStoreDataMock.reset();
+        getStoreDataMock
+            .setup(m => m(testsStub))
+            .returns(() => scanDataStub)
+            .verifiable(Times.exactly(2));
+        getTestStatusMock.reset();
+        getTestStatusMock
+            .setup(m => m(scanDataStub, selectedTestViewStub))
+            .returns(() => selectedRequirementIsEnabledStub)
+            .verifiable(Times.exactly(2));
+        getAssessmentDataMock.reset();
+        getAssessmentDataMock
+            .setup(m => m(assessmentStoreDataStub))
+            .returns(() => assessmentDataStub)
+            .verifiable(Times.once());
+        getAssessmentDataMock
+            .setup(m => m(newAssessmentStoreDataStub))
+            .returns(() => assessmentDataStub)
+            .verifiable(Times.once());
+        assessmentProviderMock.reset();
+        assessmentProviderMock
+            .setup(m => m.forType(selectedTestTypeStub))
+            .returns(() => assessmentStub)
+            .verifiable(Times.exactly(2));
+
+        const oldHandlerProps = getUpdateHandlerProps();
+        const newHandlerProps = cloneDeep(oldHandlerProps);
+        newHandlerProps.prevTarget = newTabStoreDataStub;
+        updateHandlerMock
+            .setup(u => u.update(newHandlerProps, oldHandlerProps))
+            .verifiable(Times.once());
+
+        const testObject = new AssessmentIssuesTestView(prevProps);
+
+        testObject.componentDidUpdate(newProps);
+    });
+
+    function getUpdateHandlerProps(): AssessmentViewUpdateHandlerProps {
+        return {
+            deps: depsStub,
+            selectedRequirementIsEnabled: selectedRequirementIsEnabledStub,
+            assessmentNavState: {
+                selectedTestSubview: requirementKeyStub,
+                selectedTestType: selectedTestTypeStub,
+            },
+            assessmentData: assessmentDataStub,
+            prevTarget: persistedTabInfoStub,
+            currentTarget: tabStoreDataStub,
+        };
+    }
 });


### PR DESCRIPTION
#### Details

Fix bug where, upon refresh of the target page, the visualizations in Assessment > Automated Checks are not re-enabled. This PR updates that the assessment issues test view to behave similarly to the RequirementView, which is responsible for handling this behavior (via the AssessmentViewUpdateHandler).

##### Motivation

Feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
