### PR TITLE
fix(automated-checks): prevProps causes assessment to be null

### DIFF
--- a/src/DetailsView/components/assessment-issues-test-view.tsx
+++ b/src/DetailsView/components/assessment-issues-test-view.tsx
@@ -66,18 +66,27 @@ export class AssessmentIssuesTestView extends React.Component<AssessmentIssuesTe
         props: AssessmentIssuesTestViewProps,
     ): AssessmentViewUpdateHandlerProps {
         const scanData = props.configuration.getStoreData(props.visualizationStoreData.tests);
+        const propNavState = props.assessmentStoreData.assessmentNavState;
         const selectedRequirementIsEnabled = props.configuration.getTestStatus(
             scanData,
-            props.assessmentStoreData.assessmentNavState.selectedTestSubview,
+            propNavState.selectedTestSubview,
         );
         const assessmentData = props.configuration.getAssessmentData!(props.assessmentStoreData);
-        const assessment = props.deps
-            .getProvider()
-            .forType(props.assessmentStoreData.assessmentNavState.selectedTestType);
+        const assessment = props.deps.getProvider().forType(propNavState.selectedTestType);
+
         const navState = {
-            ...props.assessmentStoreData.assessmentNavState,
-            // since no test subview/requirement is specifically selected in automated checks, we default to first requirement.
-            selectedTestSubview: assessment!.requirements[0].key,
+            selectedTestType: propNavState.selectedTestType,
+            /*
+                A couple notes:
+                1. Because we run this with the previous props and the underlying assessment
+                provider can be switched, the assessment returned can be null (i.e. looking for a
+                quick assess assessment object from prevProps using the full assessment provider or
+                vice versa).
+
+                2. Since no test subview/requirement is specifically selected in automated checks,
+                we default to first requirement.
+            */
+            selectedTestSubview: assessment?.requirements[0].key,
         } as AssessmentNavState;
 
         return {

--- a/src/tests/unit/tests/DetailsView/components/assessment-issues-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-issues-test-view.test.tsx
@@ -33,7 +33,7 @@ import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/detai
 import { shallow } from 'enzyme';
 import { cloneDeep } from 'lodash';
 import * as React from 'react';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('AssessmentIssuesTestView', () => {
     let getStoreDataMock: IMock<(data: TestsEnabledState) => ScanData>;
@@ -170,72 +170,154 @@ describe('AssessmentIssuesTestView', () => {
         updateHandlerMock.setup(u => u.onUnmount(getUpdateHandlerProps())).verifiable(Times.once());
 
         const testObject = new AssessmentIssuesTestView(propsStub);
-
         testObject.componentWillUnmount();
     });
 
-    test('componentDidUpdate', () => {
-        const newTabStoreDataStub = {
-            id: 1,
-            url: 'test-url-updated',
-            title: 'test-title-updated',
-        } as TabStoreData;
-        const newAssessmentStoreDataStub = {
-            assessmentNavState: {
-                selectedTestSubview: selectedTestViewStub,
-                selectedTestType: selectedTestTypeStub,
-            },
-            persistedTabInfo: newTabStoreDataStub,
-        } as unknown as AssessmentStoreData;
-        const newProps = {
-            configuration: configurationStub,
-            clickHandlerFactory: clickHandlerFactoryMock.object,
-            visualizationStoreData: visualizationStoreDataStub,
-            selectedTest: selectedTest,
-            scanIncompleteWarnings: [],
-            instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
-            switcherNavConfiguration: switcherNavConfigurationStub,
-            assessmentStoreData: newAssessmentStoreDataStub,
-            tabStoreData: tabStoreDataStub,
-            deps: depsStub,
-        } as AssessmentIssuesTestViewProps;
-        const prevProps = propsStub;
+    describe('componentDidUpdate', () => {
+        let newTabStoreDataStub: TabStoreData;
+        let newAssessmentStoreDataStub: AssessmentStoreData;
+        let newProps: AssessmentIssuesTestViewProps;
 
-        getStoreDataMock.reset();
-        getStoreDataMock
-            .setup(m => m(testsStub))
-            .returns(() => scanDataStub)
-            .verifiable(Times.exactly(2));
-        getTestStatusMock.reset();
-        getTestStatusMock
-            .setup(m => m(scanDataStub, selectedTestViewStub))
-            .returns(() => selectedRequirementIsEnabledStub)
-            .verifiable(Times.exactly(2));
-        getAssessmentDataMock.reset();
-        getAssessmentDataMock
-            .setup(m => m(assessmentStoreDataStub))
-            .returns(() => assessmentDataStub)
-            .verifiable(Times.once());
-        getAssessmentDataMock
-            .setup(m => m(newAssessmentStoreDataStub))
-            .returns(() => assessmentDataStub)
-            .verifiable(Times.once());
-        assessmentProviderMock.reset();
-        assessmentProviderMock
-            .setup(m => m.forType(selectedTestTypeStub))
-            .returns(() => assessmentStub)
-            .verifiable(Times.exactly(2));
+        beforeEach(() => {
+            newTabStoreDataStub = {
+                id: 1,
+                url: 'test-url-updated',
+                title: 'test-title-updated',
+            } as TabStoreData;
+            newAssessmentStoreDataStub = {
+                assessmentNavState: {
+                    selectedTestSubview: selectedTestViewStub,
+                    selectedTestType: selectedTestTypeStub,
+                },
+                persistedTabInfo: newTabStoreDataStub,
+            } as unknown as AssessmentStoreData;
+            newProps = {
+                configuration: configurationStub,
+                clickHandlerFactory: clickHandlerFactoryMock.object,
+                visualizationStoreData: visualizationStoreDataStub,
+                selectedTest: selectedTest,
+                scanIncompleteWarnings: [],
+                instancesSection: NamedFC<CommonInstancesSectionProps>('test', _ => null),
+                switcherNavConfiguration: switcherNavConfigurationStub,
+                assessmentStoreData: newAssessmentStoreDataStub,
+                tabStoreData: tabStoreDataStub,
+                deps: depsStub,
+            } as AssessmentIssuesTestViewProps;
+        });
 
-        const oldHandlerProps = getUpdateHandlerProps();
-        const newHandlerProps = cloneDeep(oldHandlerProps);
-        newHandlerProps.prevTarget = newTabStoreDataStub;
-        updateHandlerMock
-            .setup(u => u.update(newHandlerProps, oldHandlerProps))
-            .verifiable(Times.once());
+        test('calls update', () => {
+            const prevProps = propsStub;
+            getStoreDataMock.reset();
+            getStoreDataMock
+                .setup(m => m(testsStub))
+                .returns(() => scanDataStub)
+                .verifiable(Times.exactly(2));
+            getTestStatusMock.reset();
+            getTestStatusMock
+                .setup(m => m(scanDataStub, selectedTestViewStub))
+                .returns(() => selectedRequirementIsEnabledStub)
+                .verifiable(Times.exactly(2));
+            getAssessmentDataMock.reset();
+            getAssessmentDataMock
+                .setup(m => m(assessmentStoreDataStub))
+                .returns(() => assessmentDataStub)
+                .verifiable(Times.once());
+            getAssessmentDataMock
+                .setup(m => m(newAssessmentStoreDataStub))
+                .returns(() => assessmentDataStub)
+                .verifiable(Times.once());
+            assessmentProviderMock.reset();
+            assessmentProviderMock
+                .setup(m => m.forType(selectedTestTypeStub))
+                .returns(() => assessmentStub)
+                .verifiable(Times.exactly(2));
 
-        const testObject = new AssessmentIssuesTestView(prevProps);
+            const oldHandlerProps = getUpdateHandlerProps();
+            const newHandlerProps = cloneDeep(oldHandlerProps);
+            newHandlerProps.prevTarget = newTabStoreDataStub;
+            updateHandlerMock
+                .setup(u => u.update(newHandlerProps, oldHandlerProps))
+                .verifiable(Times.once());
 
-        testObject.componentDidUpdate(newProps);
+            const testObject = new AssessmentIssuesTestView(prevProps);
+
+            testObject.componentDidUpdate(newProps);
+        });
+
+        test('does not call update when prevProps match new props', () => {
+            const prevProps = propsStub;
+            getStoreDataMock.reset();
+            getStoreDataMock
+                .setup(m => m(testsStub))
+                .returns(() => scanDataStub)
+                .verifiable(Times.exactly(2));
+            getTestStatusMock.reset();
+            getTestStatusMock
+                .setup(m => m(scanDataStub, selectedTestViewStub))
+                .returns(() => selectedRequirementIsEnabledStub)
+                .verifiable(Times.exactly(2));
+            getAssessmentDataMock.reset();
+            getAssessmentDataMock
+                .setup(m => m(assessmentStoreDataStub))
+                .returns(() => assessmentDataStub)
+                .verifiable(Times.exactly(2));
+            assessmentProviderMock.reset();
+            assessmentProviderMock
+                .setup(m => m.forType(selectedTestTypeStub))
+                .returns(() => assessmentStub)
+                .verifiable(Times.exactly(2));
+
+            const oldHandlerProps = getUpdateHandlerProps();
+            const newHandlerProps = cloneDeep(oldHandlerProps);
+            newHandlerProps.prevTarget = newTabStoreDataStub;
+            updateHandlerMock
+                .setup(u => u.update(It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+
+            const testObject = new AssessmentIssuesTestView(prevProps);
+
+            testObject.componentDidUpdate(prevProps);
+        });
+
+        test('calls update with undefined prevProps.selectedTestSubview when assessment is not found', () => {
+            const prevProps = propsStub;
+            getStoreDataMock.reset();
+            getStoreDataMock
+                .setup(m => m(testsStub))
+                .returns(() => scanDataStub)
+                .verifiable(Times.exactly(2));
+            getTestStatusMock.reset();
+            getTestStatusMock
+                .setup(m => m(scanDataStub, selectedTestViewStub))
+                .returns(() => selectedRequirementIsEnabledStub)
+                .verifiable(Times.exactly(2));
+            getAssessmentDataMock.reset();
+            getAssessmentDataMock
+                .setup(m => m(assessmentStoreDataStub))
+                .returns(() => assessmentDataStub)
+                .verifiable(Times.once());
+            getAssessmentDataMock
+                .setup(m => m(newAssessmentStoreDataStub))
+                .returns(() => assessmentDataStub)
+                .verifiable(Times.once());
+            assessmentProviderMock.reset();
+            assessmentProviderMock
+                .setup(m => m.forType(selectedTestTypeStub))
+                .returns(() => null)
+                .verifiable(Times.exactly(2));
+
+            const oldHandlerProps = getUpdateHandlerProps();
+            oldHandlerProps.assessmentNavState.selectedTestSubview = undefined;
+            const newHandlerProps = cloneDeep(oldHandlerProps);
+            newHandlerProps.prevTarget = newTabStoreDataStub;
+            updateHandlerMock
+                .setup(u => u.update(newHandlerProps, oldHandlerProps))
+                .verifiable(Times.once());
+
+            const testObject = new AssessmentIssuesTestView(prevProps);
+
+            testObject.componentDidUpdate(newProps);
+        });
     });
 
     function getUpdateHandlerProps(): AssessmentViewUpdateHandlerProps {


### PR DESCRIPTION
#### Details

Will check assessment to be null before setting the selected test subview.

##### Motivation

Feature work/fixes issue where switching between quick assess and assessment would crash.

##### Context

Ideally, I'd like to make the assessment view update handler less brittle to changes of the step (likely by refactoring how step information is gotten ... maybe to the configuration objects) but unfortunately that would be a larger refactor than what I want to tackle right now.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
