### PR TITLE
fix: Launchpad links aren't visible as links in all Windows HC modes

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -156,9 +156,7 @@ html {
     @media screen and (forced-colors: active) {
         color: linktext !important;
     }
-}
 
-#popup-container .ms-Link {
     color: $communication-primary;
     font-weight: 600;
 }

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -153,6 +153,12 @@ html {
 }
 
 #popup-container .ms-Link {
+    @media screen and (forced-colors: active) {
+        color: linktext !important;
+    }
+}
+
+#popup-container .ms-Link {
     color: $communication-primary;
     font-weight: 600;
 }


### PR DESCRIPTION
#### Details

In Windows HC modes, Launchpad links are sometimes rendered in the same color as other text on the page, making them invisible. This was called out in #3476, which sort of morphed over time. Start at [this comment](https://github.com/microsoft/accessibility-insights-web/issues/3476#issuecomment-1111408632) to capture the problem being addressed by this PR.

The fix is to always render using link colors when HC modes are active. In non-HC modes, launchpad links and external links are assigned different colors. We lose that luxury in HC modes, so these internal links are rendered exactly the same as external links. It would be ideal to be able to tailor to specific HC modes, but that option is not available to us.

##### Screenshots

These screenshots capture OS Light and Dark modes, as well as  all HC themes from Win 10 and Win 11. In each screenshot, the hover state is demonstrated on the FastPass link.

Mode | Before Change | After Change
--- | --- | ---
Light mode | ![image](https://user-images.githubusercontent.com/45672944/228985363-1a38a6cc-da20-497a-a687-e8ef78af9aee.png) | ![image](https://user-images.githubusercontent.com/45672944/228985395-a42149fb-4b2e-475e-ad16-b04eff86d605.png)
Dark mode | ![image](https://user-images.githubusercontent.com/45672944/228985426-67eda608-f665-4344-a80f-0ea820b5cfae.png) | ![image](https://user-images.githubusercontent.com/45672944/228985450-9b6abd66-1acf-4b23-92dc-fa19b90d10d7.png)
Win 11 HC Aquatic | ![image](https://user-images.githubusercontent.com/45672944/228985484-0f06b75b-4d25-4592-ac17-2277244023df.png) | ![image](https://user-images.githubusercontent.com/45672944/228985512-7a58c1d5-b10d-401f-97fe-39587319ccbc.png)
Win 11 HC Desert | ![image](https://user-images.githubusercontent.com/45672944/228985547-b0d8111d-08be-4963-80b5-0b837eade138.png) | ![image](https://user-images.githubusercontent.com/45672944/228985576-c76a3f09-ee81-44ed-95bd-f2825985549b.png)
Win 11 HC Dusk | ![image](https://user-images.githubusercontent.com/45672944/228985664-5847acca-152a-4574-a01c-5e022e2ef714.png) | ![image](https://user-images.githubusercontent.com/45672944/228985714-e71170f8-091a-40a9-aa30-b8410aebc667.png) 
Win11 HC Night Sky | ![image](https://user-images.githubusercontent.com/45672944/228985759-e791c66c-ffc3-4540-9a1e-4fd4aeb320ed.png) | ![image](https://user-images.githubusercontent.com/45672944/228985780-76ac8019-4327-46df-8b24-224b4528634f.png)
Win 10 HC Black | ![image](https://user-images.githubusercontent.com/45672944/229192007-f44c3ea3-d51b-4617-a0ad-ba60e2ad05bd.png) | ![image](https://user-images.githubusercontent.com/45672944/229192160-7fc4ffa1-a6d9-4a14-8559-5546a8851171.png)
Win 10 HC 1 | ![image](https://user-images.githubusercontent.com/45672944/229192524-d56b2597-fb3b-4f25-b841-067e748e7f28.png) | ![image](https://user-images.githubusercontent.com/45672944/229192655-4d621dce-7912-4439-a669-b1b88de7683d.png)
Win 10 HC 2 | ![image](https://user-images.githubusercontent.com/45672944/229192824-dce682c0-90c7-4d98-8db5-628eb4df925f.png) | ![image](https://user-images.githubusercontent.com/45672944/229192965-bbabff20-48e6-48a4-9073-0286be7b9972.png)
Win 10 HC White | ![image](https://user-images.githubusercontent.com/45672944/229193439-7cb91035-5471-427a-b5af-51e129ab9867.png) | ![image](https://user-images.githubusercontent.com/45672944/229193570-4dd20869-b59d-4cba-9cb4-b4dd1bc71c27.png)

##### Motivation

Address #3476

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
