### PR TITLE
chore: use web version numbers as release names

### DIFF
--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -101,6 +101,7 @@ module.exports = function (grunt) {
         if (version === 'auto') {
             version = versionFromDate();
         }
+        grunt.log.writeln(`##vso[release.updatereleasename]${version}`);
         manifest.version = version;
         grunt.log.writeln(`publishing ai-web version ${version}`);
         grunt.file.write(manifestPath, JSON.stringify(manifest, undefined, 4));


### PR DESCRIPTION
#### Details

This implements a suggestion from @karanbirsingh to make the names of web releases in ADO more useful by having `/deploy/Gruntfile.js` dynamically update them to match the version of the extension being released (even when the version number is auto-generated for canary builds)

##### Motivation

Make releases easier to track backwards from

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
