### PR TITLE
fix: prevent spurious "no tab with id errors" in console

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -193,7 +193,7 @@ initializeFabricIcons();
 
 if (tabId != null) {
     void browserAdapter
-        .getTabAsync(tabId)
+        .getTab(tabId)
         .then((tab: Tab): void => {
             const telemetryFactory = new TelemetryDataFactory();
 

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 import { DetailsViewController } from 'background/details-view-controller';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { InterpreterResponse, Message } from 'common/message';
 import { Messages } from 'common/messages';
 import { DictionaryStringTo } from 'types/common-types';
-import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
+import type { Tabs } from 'webextension-polyfill';
 
 export class ExtensionDetailsViewController implements DetailsViewController {
     constructor(
@@ -31,7 +32,10 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         await Promise.all(removedTabs.map(tabId => this.onRemoveTab(tabId)));
     }
 
-    public async onUpdateTab(tabId: number, changeInfo: chrome.tabs.TabChangeInfo): Promise<void> {
+    public async onUpdateTab(
+        tabId: number,
+        changeInfo: Tabs.OnUpdatedChangeInfoType,
+    ): Promise<void> {
         const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
 
         if (targetTabId == null) {
@@ -84,7 +88,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
         }
     }
 
-    private hasUrlChange(changeInfo: chrome.tabs.TabChangeInfo, targetTabId): boolean {
+    private hasUrlChange(changeInfo: Tabs.OnUpdatedChangeInfoType, targetTabId): boolean {
         if (changeInfo.url == null) {
             return false;
         }

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -224,7 +224,6 @@ async function initializeAsync(): Promise<void> {
         tabContextManager,
         tabContextFactory,
         browserAdapter,
-        logger,
         persistedData.knownTabIds ?? {},
         indexedDBInstance,
     );

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -113,7 +113,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
     }
 
     private async updateTargetTabWithId(tabId: number): Promise<void> {
-        const tab = await this.browserAdapter.getTabAsync(tabId);
+        const tab = await this.browserAdapter.getTab(tabId);
         this.state.persistedTabInfo = {
             id: tab.id,
             url: tab.url,

--- a/src/background/tab-event-distributor.ts
+++ b/src/background/tab-event-distributor.ts
@@ -4,6 +4,7 @@
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { TargetPageController } from 'background/target-page-controller';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import type { Tabs } from 'webextension-polyfill';
 
 export class TabEventDistributor {
     constructor(
@@ -28,7 +29,7 @@ export class TabEventDistributor {
 
     private onTabRemoved = async (
         tabId: number,
-        removeInfo: chrome.tabs.TabRemoveInfo,
+        removeInfo: Tabs.OnRemovedRemoveInfoType,
     ): Promise<void> => {
         await this.targetPageController.onTargetTabRemoved(tabId);
         await this.detailsViewController.onRemoveTab(tabId);
@@ -38,14 +39,14 @@ export class TabEventDistributor {
         await this.targetPageController.onWindowFocusChanged();
     };
 
-    private onTabActivated = async (activeInfo: chrome.tabs.TabActiveInfo): Promise<void> => {
+    private onTabActivated = async (activeInfo: Tabs.OnActivatedActiveInfoType): Promise<void> => {
         await this.targetPageController.onTabActivated(activeInfo);
     };
 
     private onTabUpdated = async (
         tabId: number,
-        changeInfo: chrome.tabs.TabChangeInfo,
-        tab: chrome.tabs.Tab,
+        changeInfo: Tabs.OnUpdatedChangeInfoType,
+        tab: Tabs.Tab,
     ): Promise<void> => {
         await this.targetPageController.onTabUpdated(tabId, changeInfo);
         await this.detailsViewController.onUpdateTab(tabId, changeInfo);

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -140,6 +140,12 @@ export class TargetPageController {
     };
 
     private handleTabUrlUpdate = async (tabId: number): Promise<void> => {
+        this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory);
+        await this.sendTabUrlUpdatedAction(tabId);
+        await this.addKnownTabId(tabId);
+    };
+
+    private async sendTabUrlUpdatedAction(tabId: number): Promise<void> {
         let tab: Tabs.Tab;
         try {
             tab = await this.browserAdapter.getTab(tabId);
@@ -149,12 +155,6 @@ export class TargetPageController {
             return;
         }
 
-        this.tabContextManager.addTabContextIfNotExists(tabId, this.tabContextFactory);
-        await this.sendTabUrlUpdatedAction(tab);
-        await this.addKnownTabId(tabId);
-    };
-
-    private async sendTabUrlUpdatedAction(tab: Tabs.Tab): Promise<void> {
         await this.interpretMessageAsync({
             messageType: Messages.Tab.ExistingTabUpdated,
             payload: tab,

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -14,16 +14,14 @@ import {
 export interface BrowserAdapter {
     allSupportedEvents(): DictionaryStringTo<Events.Event<any>>;
     getAllWindows(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]>;
-    addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void;
+    addListenerToTabsOnActivated(
+        callback: (activeInfo: Tabs.OnActivatedActiveInfoType) => void,
+    ): void;
     addListenerToTabsOnUpdated(
-        callback: (
-            tabId: number,
-            changeInfo: chrome.tabs.TabChangeInfo,
-            tab: chrome.tabs.Tab,
-        ) => void,
+        callback: (tabId: number, changeInfo: Tabs.OnUpdatedChangeInfoType, tab: Tabs.Tab) => void,
     ): void;
     addListenerToTabsOnRemoved(
-        callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void,
+        callback: (tabId: number, removeInfo: Tabs.OnRemovedRemoveInfoType) => void,
     ): void;
     addListenerToWebNavigationUpdated(
         callback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void,

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -34,7 +34,7 @@ export interface BrowserAdapter {
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): Promise<void>;
     updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
-    getTab(tabId: number): Promise<chrome.tabs.Tab>;
+    getTab(tabId: number): Promise<Tabs.Tab>;
     updateWindow(
         windowId: number,
         updateProperties: Windows.UpdateUpdateInfoType,

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -34,7 +34,7 @@ export interface BrowserAdapter {
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): Promise<void>;
     updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
-    getTabAsync(tabId: number): Promise<chrome.tabs.Tab>;
+    getTab(tabId: number): Promise<chrome.tabs.Tab>;
     updateWindow(
         windowId: number,
         updateProperties: Windows.UpdateUpdateInfoType,

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -39,8 +39,8 @@ export abstract class WebExtensionBrowserAdapter
         };
     }
 
-    public getAllWindows(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]> {
-        return browser.windows.getAll(getInfo);
+    public async getAllWindows(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]> {
+        return await browser.windows.getAll(getInfo);
     }
 
     public addListenerToTabsOnActivated(
@@ -75,20 +75,12 @@ export abstract class WebExtensionBrowserAdapter
         this.addListener('WindowsOnFocusChanged', callback);
     }
 
-    public tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> {
-        return browser.tabs.query(query);
+    public async tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> {
+        return await browser.tabs.query(query);
     }
 
-    public async getTabAsync(tabId: number): Promise<chrome.tabs.Tab> {
-        return new Promise((resolve, reject) => {
-            chrome.tabs.get(tabId, tab => {
-                if (tab) {
-                    resolve(tab);
-                } else {
-                    reject(new Error(`tab with Id ${tabId} not found`));
-                }
-            });
-        });
+    public async getTab(tabId: number): Promise<Tabs.Tab> {
+        return await browser.tabs.get(tabId);
     }
 
     private verifyPathCompatibility(path?: string): void {
@@ -103,7 +95,7 @@ export abstract class WebExtensionBrowserAdapter
         }
     }
 
-    public executeScriptInTab(
+    public async executeScriptInTab(
         tabId: number,
         details: {
             file: string;
@@ -112,14 +104,14 @@ export abstract class WebExtensionBrowserAdapter
     ): Promise<any[]> {
         this.verifyPathCompatibility(details.file);
         return typeof browser.tabs.executeScript === 'function'
-            ? browser.tabs.executeScript(tabId, details)
-            : chrome.scripting.executeScript({
+            ? await browser.tabs.executeScript(tabId, details)
+            : await chrome.scripting.executeScript({
                   target: { tabId, allFrames: details.allFrames },
                   files: [details.file],
               });
     }
 
-    public insertCSSInTab(
+    public async insertCSSInTab(
         tabId: number,
         details: {
             file: string;
@@ -128,15 +120,15 @@ export abstract class WebExtensionBrowserAdapter
     ): Promise<void> {
         this.verifyPathCompatibility(details.file);
         return typeof browser.tabs.insertCSS === 'function'
-            ? browser.tabs.insertCSS(tabId, details)
-            : chrome.scripting.insertCSS({
+            ? await browser.tabs.insertCSS(tabId, details)
+            : await chrome.scripting.insertCSS({
                   target: { tabId, allFrames: details.allFrames },
                   files: [details.file],
               });
     }
 
-    public createActiveTab(url: string): Promise<Tabs.Tab> {
-        return browser.tabs.create({ url, active: true, pinned: false });
+    public async createActiveTab(url: string): Promise<Tabs.Tab> {
+        return await browser.tabs.create({ url, active: true, pinned: false });
     }
 
     public async createTabInNewWindow(url: string): Promise<Tabs.Tab> {
@@ -147,18 +139,18 @@ export abstract class WebExtensionBrowserAdapter
         return newWindow.tabs[0];
     }
 
-    public updateTab(
+    public async updateTab(
         tabId: number,
         updateProperties: Tabs.UpdateUpdatePropertiesType,
     ): Promise<Tabs.Tab> {
-        return browser.tabs.update(tabId, updateProperties);
+        return await browser.tabs.update(tabId, updateProperties);
     }
 
-    public updateWindow(
+    public async updateWindow(
         windowId: number,
         updateProperties: Windows.UpdateUpdateInfoType,
     ): Promise<Windows.Window> {
-        return browser.windows.update(windowId, updateProperties);
+        return await browser.windows.update(windowId, updateProperties);
     }
 
     public async switchToTab(tabId: number): Promise<void> {
@@ -169,40 +161,42 @@ export abstract class WebExtensionBrowserAdapter
         await this.updateWindow(tab.windowId, { focused: true });
     }
 
-    public sendMessageToTab(tabId: number, message: any): Promise<void> {
-        return browser.tabs.sendMessage(tabId, message);
+    public async sendMessageToTab(tabId: number, message: any): Promise<void> {
+        return await browser.tabs.sendMessage(tabId, message);
     }
 
-    public sendMessageToFrames(message: any): Promise<void> {
-        return browser.runtime.sendMessage(message);
+    public async sendMessageToFrames(message: any): Promise<void> {
+        return await browser.runtime.sendMessage(message);
     }
 
     public async sendRuntimeMessage(message: any): Promise<any> {
         return await browser.runtime.sendMessage(message);
     }
 
-    public setUserData(items: Object): Promise<void> {
-        return browser.storage.local.set(items);
+    public async setUserData(items: Object): Promise<void> {
+        return await browser.storage.local.set(items);
     }
 
-    public getUserData(keys: string[]): Promise<{ [key: string]: any }> {
-        return browser.storage.local.get(keys);
+    public async getUserData(keys: string[]): Promise<{ [key: string]: any }> {
+        return await browser.storage.local.get(keys);
     }
 
-    public removeUserData(key: string): Promise<void> {
-        return browser.storage.local.remove(key);
+    public async removeUserData(key: string): Promise<void> {
+        return await browser.storage.local.remove(key);
     }
 
     public getRuntimeLastError(): chrome.runtime.LastError | undefined {
         return chrome.runtime.lastError;
     }
 
-    public createNotification(options: Notifications.CreateNotificationOptions): Promise<string> {
-        return browser.notifications.create(options);
+    public async createNotification(
+        options: Notifications.CreateNotificationOptions,
+    ): Promise<string> {
+        return await browser.notifications.create(options);
     }
 
-    public isAllowedFileSchemeAccess(): Promise<boolean> {
-        return browser.extension.isAllowedFileSchemeAccess();
+    public async isAllowedFileSchemeAccess(): Promise<boolean> {
+        return await browser.extension.isAllowedFileSchemeAccess();
     }
 
     public addCommandListener(callback: (command: string) => void): void {
@@ -241,8 +235,8 @@ export abstract class WebExtensionBrowserAdapter
         return browser.runtime.getURL(urlPart);
     }
 
-    public requestPermissions(permissions: Permissions.Permissions): Promise<boolean> {
-        return browser.permissions.request(permissions);
+    public async requestPermissions(permissions: Permissions.Permissions): Promise<boolean> {
+        return await browser.permissions.request(permissions);
     }
 
     public addListenerOnPermissionsAdded(
@@ -257,8 +251,8 @@ export abstract class WebExtensionBrowserAdapter
         this.addListener('PermissionsOnRemoved', callback);
     }
 
-    public containsPermissions(permissions: Permissions.Permissions): Promise<boolean> {
-        return browser.permissions.contains(permissions);
+    public async containsPermissions(permissions: Permissions.Permissions): Promise<boolean> {
+        return await browser.permissions.contains(permissions);
     }
 
     public getInspectedWindowTabId(): number | null {

--- a/src/common/browser-adapters/webextension-browser-adapter.ts
+++ b/src/common/browser-adapters/webextension-browser-adapter.ts
@@ -44,17 +44,13 @@ export abstract class WebExtensionBrowserAdapter
     }
 
     public addListenerToTabsOnActivated(
-        callback: (activeInfo: chrome.tabs.TabActiveInfo) => void,
+        callback: (activeInfo: Tabs.OnActivatedActiveInfoType) => void,
     ): void {
         this.addListener('TabsOnActivated', callback);
     }
 
     public addListenerToTabsOnUpdated(
-        callback: (
-            tabId: number,
-            changeInfo: chrome.tabs.TabChangeInfo,
-            tab: chrome.tabs.Tab,
-        ) => void,
+        callback: (tabId: number, changeInfo: Tabs.OnUpdatedChangeInfoType, tab: Tabs.Tab) => void,
     ): void {
         this.addListener('TabsOnUpdated', callback);
     }
@@ -66,7 +62,7 @@ export abstract class WebExtensionBrowserAdapter
     }
 
     public addListenerToTabsOnRemoved(
-        callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void,
+        callback: (tabId: number, removeInfo: Tabs.OnRemovedRemoveInfoType) => void,
     ): void {
         this.addListener('TabsOnRemoved', callback);
     }

--- a/src/popup/target-tab-finder.ts
+++ b/src/popup/target-tab-finder.ts
@@ -36,7 +36,7 @@ export class TargetTabFinder {
                     return tabs.pop()!;
                 });
         } else {
-            return this.browserAdapter.getTabAsync(tabIdInUrl);
+            return this.browserAdapter.getTab(tabIdInUrl);
         }
     };
 

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -20,18 +20,18 @@ export type SimulatedBrowserAdapter = IMock<BrowserAdapter> & {
     //
     // Tests are responsible for maintaining self-consistency (ie, ensuring all tabs have corresponding windows)
     windows: chrome.windows.Window[];
-    tabs: chrome.tabs.Tab[];
+    tabs: Tabs.Tab[];
 
     // These are set directly to whichever listener was last registered in the corresponding this.object.addListener* call
-    notifyTabsOnActivated?: (activeInfo: chrome.tabs.TabActiveInfo) => void | Promise<void>;
+    notifyTabsOnActivated?: (activeInfo: Tabs.OnActivatedActiveInfoType) => void | Promise<void>;
     notifyTabsOnUpdated?: (
         tabId: number,
-        changeInfo: chrome.tabs.TabChangeInfo,
-        tab: chrome.tabs.Tab,
+        changeInfo: Tabs.OnUpdatedChangeInfoType,
+        tab: Tabs.Tab,
     ) => void | Promise<void>;
     notifyTabsOnRemoved?: (
         tabId: number,
-        removeInfo: chrome.tabs.TabRemoveInfo,
+        removeInfo: Tabs.OnRemovedRemoveInfoType,
     ) => void | Promise<void>;
     notifyWebNavigationUpdated?: (
         details: chrome.webNavigation.WebNavigationFramedCallbackDetails,
@@ -39,8 +39,8 @@ export type SimulatedBrowserAdapter = IMock<BrowserAdapter> & {
     notifyWindowsFocusChanged?: (windowId: number) => void | Promise<void>;
 
     // These simulate real "update"/"activate" events (they update the windows/tabs state and send the notifications)
-    updateTab: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo) => void | Promise<void>;
-    activateTab: (tab: chrome.tabs.Tab) => void | Promise<void>;
+    updateTab: (tabId: number, changeInfo: Tabs.OnUpdatedChangeInfoType) => void | Promise<void>;
+    activateTab: (tab: Tabs.Tab) => void | Promise<void>;
 
     // This simulates normal browser runtime.onMessage behavior:
     //  - it loops through each listener previously registered with addListenerOnMessage
@@ -52,7 +52,7 @@ export type SimulatedBrowserAdapter = IMock<BrowserAdapter> & {
 };
 
 export function createSimulatedBrowserAdapter(
-    tabs?: chrome.tabs.Tab[],
+    tabs?: Tabs.Tab[],
     windows?: chrome.windows.Window[],
 ): SimulatedBrowserAdapter {
     const mock: Partial<SimulatedBrowserAdapter> & IMock<BrowserAdapter> =

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -118,7 +118,7 @@ export function createSimulatedBrowserAdapter(
         });
         if (tabToActivate.id != null) {
             await mock.notifyTabsOnActivated!({
-                windowId: tabToActivate.windowId,
+                windowId: tabToActivate.windowId!,
                 tabId: tabToActivate.id,
             });
         }

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -15,7 +15,7 @@ import { Runtime, Tabs, Windows } from 'webextension-polyfill';
 export type SimulatedBrowserAdapter = IMock<BrowserAdapter> & {
     // Tests may modify this state directly; updates will be reflected in the following default mock implementations:
     //   * this.object.getAllWindows
-    //   * this.object.getTabAsync
+    //   * this.object.getTab
     //   * this.object.tabsQuery
     //
     // Tests are responsible for maintaining self-consistency (ie, ensuring all tabs have corresponding windows)
@@ -83,7 +83,7 @@ export function createSimulatedBrowserAdapter(
     mock.setup(m => m.getAllWindows(It.isAny())).returns(() =>
         Promise.resolve(mock.windows as Windows.Window[]),
     );
-    mock.setup(m => m.getTabAsync(It.isAny())).returns(async tabId => {
+    mock.setup(m => m.getTab(It.isAny())).returns(async tabId => {
         const matchingTabs = mock.tabs!.filter(tab => tab.id === tabId);
         if (matchingTabs.length === 1) {
             return matchingTabs[0];

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -485,7 +485,7 @@ describe('AssessmentStore', () => {
             title,
         } as chrome.tabs.Tab;
         browserMock
-            .setup(b => b.getTabAsync(tabId))
+            .setup(b => b.getTab(tabId))
             .returns(async () => tab)
             .verifiable();
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
@@ -550,7 +550,7 @@ describe('AssessmentStore', () => {
             title,
         } as chrome.tabs.Tab;
         browserMock
-            .setup(b => b.getTabAsync(tabId))
+            .setup(b => b.getTab(tabId))
             .returns(async () => tab)
             .verifiable();
 
@@ -593,7 +593,7 @@ describe('AssessmentStore', () => {
             title,
         } as chrome.tabs.Tab;
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
-        browserMock.setup(adapter => adapter.getTabAsync(tabId)).returns(async () => tab);
+        browserMock.setup(adapter => adapter.getTab(tabId)).returns(async () => tab);
 
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
@@ -629,7 +629,7 @@ describe('AssessmentStore', () => {
         } as chrome.tabs.Tab;
 
         beforeEach(() => {
-            browserMock.setup(adapter => adapter.getTabAsync(tabId)).returns(async () => tab);
+            browserMock.setup(adapter => adapter.getTab(tabId)).returns(async () => tab);
         });
 
         test('with tab info', async () => {
@@ -1208,7 +1208,7 @@ describe('AssessmentStore', () => {
                 .build();
 
             browserMock
-                .setup(b => b.getTabAsync(tabId))
+                .setup(b => b.getTab(tabId))
                 .returns(async () => tab)
                 .verifiable();
 
@@ -1218,7 +1218,7 @@ describe('AssessmentStore', () => {
         });
 
         test('with no tab id change', async () => {
-            browserMock.setup(b => b.getTabAsync(It.isAny())).verifiable(Times.never());
+            browserMock.setup(b => b.getTab(It.isAny())).verifiable(Times.never());
             const initialState = new AssessmentsStoreDataBuilder(
                 assessmentsProvider,
                 assessmentDataConverterMock.object,

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -54,14 +54,15 @@ import {
 import { cloneDeep } from 'lodash';
 import { getIncludedAlwaysRules } from 'scanner/get-rule-inclusions';
 import { ScanResults } from 'scanner/iruleresults';
+import { AssessmentDataBuilder } from 'tests/unit/common/assessment-data-builder';
+import { AssessmentsStoreDataBuilder } from 'tests/unit/common/assessment-store-data-builder';
+import { AssessmentStoreTester } from 'tests/unit/common/assessment-store-tester';
 import { failTestOnErrorLogger } from 'tests/unit/common/fail-test-on-error-logger';
+import { createStoreWithNullParams } from 'tests/unit/common/store-tester';
+import { CreateTestAssessmentProvider } from 'tests/unit/common/test-assessment-provider';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
-import { AssessmentDataBuilder } from '../../../common/assessment-data-builder';
-import { AssessmentsStoreDataBuilder } from '../../../common/assessment-store-data-builder';
-import { AssessmentStoreTester } from '../../../common/assessment-store-tester';
-import { createStoreWithNullParams } from '../../../common/store-tester';
-import { CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
+import type { Tabs } from 'webextension-polyfill';
 
 const assessmentKey: string = 'assessment-1';
 const requirementKey: string = 'assessment-1-step-1';
@@ -483,7 +484,7 @@ describe('AssessmentStore', () => {
             id: tabId,
             url,
             title,
-        } as chrome.tabs.Tab;
+        } as Tabs.Tab;
         browserMock
             .setup(b => b.getTab(tabId))
             .returns(async () => tab)
@@ -548,7 +549,7 @@ describe('AssessmentStore', () => {
             id: tabId,
             url,
             title,
-        } as chrome.tabs.Tab;
+        } as Tabs.Tab;
         browserMock
             .setup(b => b.getTab(tabId))
             .returns(async () => tab)
@@ -591,7 +592,7 @@ describe('AssessmentStore', () => {
             id: tabId,
             url,
             title,
-        } as chrome.tabs.Tab;
+        } as Tabs.Tab;
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
         browserMock.setup(adapter => adapter.getTab(tabId)).returns(async () => tab);
 
@@ -626,7 +627,7 @@ describe('AssessmentStore', () => {
             id: tabId,
             url,
             title,
-        } as chrome.tabs.Tab;
+        } as Tabs.Tab;
 
         beforeEach(() => {
             browserMock.setup(adapter => adapter.getTab(tabId)).returns(async () => tab);
@@ -1188,7 +1189,7 @@ describe('AssessmentStore', () => {
             id: tabId,
             url,
             title,
-        } as chrome.tabs.Tab;
+        } as Tabs.Tab;
 
         it.each([undefined, { tabId: 2000 }])('with persisted tab=%s', async persistedTab => {
             const storeDataBuilder = new AssessmentsStoreDataBuilder(

--- a/src/tests/unit/tests/background/tab-event-distributor.test.ts
+++ b/src/tests/unit/tests/background/tab-event-distributor.test.ts
@@ -9,12 +9,13 @@ import {
     SimulatedBrowserAdapter,
 } from 'tests/unit/common/simulated-browser-adapter';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
+import type { Tabs } from 'webextension-polyfill';
 
 describe(TabEventDistributor, () => {
     const tab = {
         id: 1,
         windowId: 101,
-    } as chrome.tabs.Tab;
+    } as Tabs.Tab;
 
     let browserAdapterMock: SimulatedBrowserAdapter;
     let targetPageControllerMock: IMock<TargetPageController>;
@@ -59,7 +60,7 @@ describe(TabEventDistributor, () => {
         targetPageControllerMock.setup(t => t.onTargetTabRemoved(tab.id)).verifiable();
         detailsViewControllerMock.setup(d => d.onRemoveTab(tab.id)).verifiable();
 
-        await browserAdapterMock.notifyTabsOnRemoved(tab.id, {} as chrome.tabs.TabRemoveInfo);
+        await browserAdapterMock.notifyTabsOnRemoved(tab.id, {} as Tabs.OnRemovedRemoveInfoType);
     });
 
     it('onWindowsFocusChanged event', async () => {
@@ -79,7 +80,7 @@ describe(TabEventDistributor, () => {
     });
 
     it('onTabUpdated event', async () => {
-        const changeInfo: chrome.tabs.TabChangeInfo = {};
+        const changeInfo: Tabs.OnUpdatedChangeInfoType = {};
 
         targetPageControllerMock.setup(t => t.onTabUpdated(tab.id, changeInfo)).verifiable();
         detailsViewControllerMock.setup(d => d.onUpdateTab(tab.id, changeInfo)).verifiable();

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -5,7 +5,7 @@ import { UrlParser } from 'common/url-parser';
 import { UrlValidator } from 'common/url-validator';
 import { TargetTabFinder } from 'popup/target-tab-finder';
 import { IMock, Mock } from 'typemoq';
-import { Tabs } from 'webextension-polyfill';
+import type { Tabs } from 'webextension-polyfill';
 
 describe('TargetTabFinderTest', () => {
     let testSubject: TargetTabFinder;
@@ -110,9 +110,7 @@ describe('TargetTabFinderTest', () => {
     }
 
     function setupGetTabCall(): void {
-        browserAdapterMock
-            .setup(b => b.getTab(tabId))
-            .returns(async () => tabStub as chrome.tabs.Tab);
+        browserAdapterMock.setup(b => b.getTab(tabId)).returns(async () => tabStub as Tabs.Tab);
     }
 
     function setupTabQueryCall(returnValue: Tabs.Tab[]): void {

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -87,7 +87,7 @@ describe('TargetTabFinderTest', () => {
         const testError = new Error('Tab not found');
         setupGetTabIdParamFromUrl(tabId);
         browserAdapterMock
-            .setup(b => b.getTabAsync(tabId))
+            .setup(b => b.getTab(tabId))
             .returns(async () => {
                 throw testError;
             });
@@ -111,7 +111,7 @@ describe('TargetTabFinderTest', () => {
 
     function setupGetTabCall(): void {
         browserAdapterMock
-            .setup(b => b.getTabAsync(tabId))
+            .setup(b => b.getTab(tabId))
             .returns(async () => tabStub as chrome.tabs.Tab);
     }
 


### PR DESCRIPTION
#### Details

This PR removes some spurious error spew from the service worker console along the lines of:

```
Unchecked runtime.lastError: no tab with id: 12345678
sendTabUrlUpdatedAction: tab with ID 12345678 not found, skipping action message
```

The `sendTabUrlUpdatedAction` part happens because `TargetPageController` is printing a message when it sees a browser update/navigate event for a tab that it can't successfully query the browser for information about. However, that case happens commonly in normal operation - for example, the browser sends such a navigation event every time you open a new tab because it sends us a navigation event as it preloads the new tab content in a tab that isn't visible to our extension. The message looks like an error but it isn't; less confusing to omit it.

The `Unchecked runtime.lastError` part happens because `WebextensionBrowserAdapter.getTabAsync` was still using the non-async `chrome.tabs.getTab` API and manually converting it to a Promise-based API, but was doing so incorrectly in that it wasn't checking `chrome.runtime.getLastError` on error like it's supposed to. This PR fixes that by just converting it to use the async version of the API directly.

While I was there, I also normalized all the rest of the async `WebextensionBrowserAdapter` implementations to consistently use `await` instead of directly returning browser promises. This has no functional impact but makes it easier to debug these methods - it enables better stack traces when an error occurs there and also improves the behavior of breakpoints there.

##### Motivation

Avoid misleading looking errors in console

##### Context

The changes that are particularly interesting to review are in `target-page-controller.ts` - most of the individual lines changes are just:
* typings changes from `chrome.tabs.*` types to equivalent `Tab.*` types to accomadate the use of the async API.
* updating the name of the API from `getTabAsync` to just `getTab` (for consistency; none of the other async browser adapter methods use the `*Async` naming convention)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
