### PR TITLE
fix: prevent UI getting stuck loading after service worker upgrades

### DIFF
--- a/src/background/service-worker-activator.ts
+++ b/src/background/service-worker-activator.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This class handles the coordination between an "old" worker and a "new" worker when an
+// extension upgrade occurs (including when the dev extension is rebuilt without reloading).
+// Chromium will start the new worker *concurrently* with the old one in that case. The intent is
+// for the new worker to end up in an "installed" (but not "activated" state), for the old worker
+// (in an "activated" state) to continue to service requests for any pre-exisiting clients, and
+// for the old worker to only get cleaned up once all connected clients close, at which point the
+// new worker can "activate".
+//
+// This doesn't cooperate well with our architecture, which generally assumes that background
+// lifetime works more like how background pages worked before Chromium switched to service workers,
+// where only one background instance exists at a time. The most obvious issue this causes is when
+// messages from clients to workers appear to get lost due to both workers trying to process them
+// and only one succeeding, which tends to result in all of our UI getting stuck in loading spinners
+// as initial store state messages get lost. A more serious issue is that the two worker instances
+// risk stomping on each other's persisted state if they're both responding to client messages
+// simultaneously.
+export class ServiceWorkerActivator {
+    private activatedPromise: Promise<void>;
+
+    // This registers a service worker event handler, so it must be constructed during the sync
+    // portion of service worker initialization.
+    constructor(private readonly serviceWorkerGlobalScope: ServiceWorkerGlobalScope) {
+        this.activatedPromise = new Promise(resolve => {
+            serviceWorkerGlobalScope.addEventListener('activate', () => resolve());
+        });
+    }
+
+    public async claimExistingServiceWorkerClients() {
+        if (this.serviceWorkerGlobalScope.serviceWorker.state !== 'activated') {
+            console.debug('New service worker version detected, forcing activation');
+            // This tells the browser to move this worker from the "installed" state to the
+            // "activated" state without waiting for existing clients to close.
+            await this.serviceWorkerGlobalScope.skipWaiting();
+            await this.activatedPromise;
+        }
+
+        // This tells existing clients to disconnect from any old worker instance and reconnect to
+        // this one. It will throw an error if called from outside the "activated" state.
+        await this.serviceWorkerGlobalScope.clients.claim();
+    }
+}

--- a/src/background/service-worker-init.ts
+++ b/src/background/service-worker-init.ts
@@ -95,7 +95,7 @@ function initializeSync(): void {
 }
 
 async function initializeAsync(): Promise<void> {
-    // This should happen *before* other initialization steps that involves persisted data
+    // This should happen *before* other initialization steps that involve persisted data
     await serviceWorkerActivator.claimExistingServiceWorkerClients();
 
     // This only removes keys that are unused by current versions of the extension, so it's okay for it to race with everything else

--- a/src/background/telemetry/telemetry-event-handler.ts
+++ b/src/background/telemetry/telemetry-event-handler.ts
@@ -8,18 +8,18 @@ import { BaseActionPayload } from '../actions/action-payloads';
 import { TelemetryClient } from './telemetry-client';
 
 export class TelemetryEventHandler {
-    private telemetryClient: TelemetryClient;
+    private telemetryClient: TelemetryClient | null = null;
 
     public initialize(telemetryClient: TelemetryClient): void {
         this.telemetryClient = telemetryClient;
     }
 
     public enableTelemetry(): void {
-        this.telemetryClient.enableTelemetry();
+        this.telemetryClient!.enableTelemetry();
     }
 
     public disableTelemetry(): void {
-        this.telemetryClient.disableTelemetry();
+        this.telemetryClient!.disableTelemetry();
     }
 
     public publishTelemetry(eventName: string, payload: BaseActionPayload): void {
@@ -33,7 +33,7 @@ export class TelemetryEventHandler {
         const flattenTelemetryInfo: DictionaryStringTo<string> =
             this.flattenTelemetryInfo(telemetryInfo);
 
-        this.telemetryClient.trackEvent(eventName, flattenTelemetryInfo);
+        this.telemetryClient?.trackEvent(eventName, flattenTelemetryInfo);
     }
 
     private addBasicDataToTelemetry(telemetryInfo: any): void {

--- a/src/tests/unit/tests/background/service-worker-activator.test.ts
+++ b/src/tests/unit/tests/background/service-worker-activator.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ServiceWorkerActivator } from 'background/service-worker-activator';
+
+describe(ServiceWorkerActivator, () => {
+    let simulatedGlobalScope: ServiceWorkerGlobalScope;
+    let activateCallback: Function | null;
+    let testSubject: ServiceWorkerActivator;
+
+    let claimFn: jest.Mock<Promise<void>>;
+    let skipWaitingFn: jest.Mock<Promise<void>>;
+
+    beforeEach(() => {
+        claimFn = jest.fn(() => Promise.resolve());
+        skipWaitingFn = jest.fn(() => Promise.resolve());
+
+        activateCallback = null;
+        simulatedGlobalScope = {
+            addEventListener: (eventName, cb) => {
+                expect(eventName).toBe('activate');
+                activateCallback = cb;
+            },
+            clients: {
+                claim: claimFn as () => Promise<void>,
+            } as Clients,
+            serviceWorker: {
+                state: 'activated',
+            },
+            skipWaiting: skipWaitingFn as () => Promise<void>,
+        } as ServiceWorkerGlobalScope;
+
+        testSubject = new ServiceWorkerActivator(simulatedGlobalScope);
+    });
+
+    describe('constructor', () => {
+        it('registers an activate listener synchronously', () => {
+            expect(activateCallback).not.toBeNull();
+        });
+    });
+
+    describe('claimExistingServiceWorkerClients', () => {
+        let testSubject: ServiceWorkerActivator;
+
+        beforeEach(() => {
+            testSubject = new ServiceWorkerActivator(simulatedGlobalScope);
+        });
+
+        it('always claims existing service worker clients', async () => {
+            await testSubject.claimExistingServiceWorkerClients();
+
+            expect(claimFn).toHaveBeenCalledTimes(1);
+        });
+
+        it('forces a transition to the "activated" state if necessary', async () => {
+            (simulatedGlobalScope.serviceWorker.state as any) = 'installed';
+            const claimPromise = testSubject.claimExistingServiceWorkerClients();
+
+            activateCallback();
+
+            await claimPromise;
+
+            expect(skipWaitingFn).toHaveBeenCalledTimes(1);
+            expect(claimFn).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not wait for an "activate" event if already in the "activated" state', async () => {
+            (simulatedGlobalScope.serviceWorker.state as any) = 'activated';
+            await testSubject.claimExistingServiceWorkerClients();
+
+            // intentionally not invoking activateCallback();
+
+            expect(skipWaitingFn).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/tests/unit/tests/background/service-worker-activator.test.ts
+++ b/src/tests/unit/tests/background/service-worker-activator.test.ts
@@ -39,12 +39,6 @@ describe(ServiceWorkerActivator, () => {
     });
 
     describe('claimExistingServiceWorkerClients', () => {
-        let testSubject: ServiceWorkerActivator;
-
-        beforeEach(() => {
-            testSubject = new ServiceWorkerActivator(simulatedGlobalScope);
-        });
-
         it('always claims existing service worker clients', async () => {
             await testSubject.claimExistingServiceWorkerClients();
 

--- a/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
@@ -3,15 +3,12 @@
 import { BaseActionPayload } from 'background/actions/action-payloads';
 import { TelemetryClient } from 'background/telemetry/telemetry-client';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource, TriggeredBy } from 'common/extension-telemetry-events';
 import { each } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import {
-    TelemetryEventSource,
-    TriggeredBy,
-} from '../../../../../common/extension-telemetry-events';
-import { DictionaryStringTo } from '../../../../../types/common-types';
+import { DictionaryStringTo } from 'types/common-types';
 
-describe('TelemetryEventHandlerTest', () => {
+describe(TelemetryEventHandler, () => {
     let telemetryClientStrictMock: IMock<TelemetryClient>;
     let testEventName;
     let testTelemetryPayload;
@@ -28,13 +25,18 @@ describe('TelemetryEventHandlerTest', () => {
         telemetryClientStrictMock = Mock.ofType<TelemetryClient>(null, MockBehavior.Strict);
     });
 
-    test('test for when telemetry is null', () => {
+    test('should silently noop when telemetry is null', () => {
         const payload: BaseActionPayload = {
             telemetry: null,
         };
 
         const testObject = createAndEnableTelemetryEventHandler();
         testObject.publishTelemetry(testEventName, payload);
+    });
+
+    test('trackEvent should silently noop when not yet initialized', () => {
+        const testObject = new TelemetryEventHandler();
+        testObject.publishTelemetry(testEventName, testTelemetryPayload);
     });
 
     test('test for when tab is null', () => {


### PR DESCRIPTION
#### Details

This PR addresses an issue that could occur when upgrading the extension (including when rebuilding dev locally without reloading) where you could end up in a state with multiple service worker instances running and store initialization messages getting lost due to not targeting the authoritative one. All the app's UIs would then get stuck in loading spinners waiting for initial store state messages to get sent in reply to messages that are never received.

To achieve this, we add a new component near the beginning of the `service-worker-init` path which detects the case where the initializing service worker is not yet considered "activated" by the browser (because an old worker still exists), and forces the browser to treat the new worker as the "active" one and "claim" the communications of any pre-existing clients (details views, content scripts, etc) from the old worker to the new one.

I expect this to resolve the "stuck on loading spinner" issues that we see during regular development in dev builds, but I do *not* necessarily expect this to fix the version of #6524 that persists across uninstalling + reinstalling the extension like was reported in [this SO post](https://stackoverflow.com/questions/75751002/insights-wont-launch-just-buffers). I suspect what's probably happening there is some error getting thrown during service worker initialization, which would cause the same symptom.

I also included a minor fix to the `TelemetryEventHandler` I noticed while working on this where it accidentally masks the true stacks of exceptions that occur early in initialization before the telemetry client is initialized.

##### Motivation

Partially addresses #6524

##### Context

Reference material on service worker lifetimes I used while writing this:

* [MDN docs on updating service workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#updating_your_service_worker)
* [Helpful blog post tying together several different aspects of managing worker lifetime](https://web.dev/service-worker-lifecycle/)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6524 (partially)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
