### PR TITLE
fix: improve skip link definition link in Bypass Blocks assessment test

### DIFF
--- a/src/assessments/repetitive-content/test-steps/bypass-blocks.tsx
+++ b/src/assessments/repetitive-content/test-steps/bypass-blocks.tsx
@@ -31,9 +31,7 @@ const bypassBlocksHowToTest: JSX.Element = (
             <li>
                 Use the <Markup.Term>Tab</Markup.Term> key to navigate toward the primary content.
                 As you navigate, look for a bypass mechanism (typically a{' '}
-                <NewTabLink href="https://dequeuniversity.com/rules/axe/3.1/skip-link">
-                    skip link
-                </NewTabLink>
+                <NewTabLink href="https://webaim.org/techniques/skipnav/">skip link</NewTabLink>
                 ). The mechanism might not become visible until it receives focus.
             </li>
             <li>


### PR DESCRIPTION
#### Details

Updates the link for term `skip link` in our Bypass Blocks assessment test per suggestion from #6477

##### Motivation

Addresses #6477

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6477
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
