### PR TITLE
chore: Remove suppression that bugs TypeScript 5

### DIFF
--- a/src/assessments/automated-checks/build-test-steps-from-rules.tsx
+++ b/src/assessments/automated-checks/build-test-steps-from-rules.tsx
@@ -52,8 +52,6 @@ function buildAutomatedCheckStep(rule: ScannerRuleInfo): Requirement {
         getInstanceStatus: getInstanceStatus,
         getInstanceStatusColumns: () => [],
         instanceTableHeaderType: 'none',
-        renderRequirementDescription: requirementLink =>
-            requirementLink.renderRequirementDescriptionWithoutIndex(),
         getDefaultMessage: defaultMessageGenerator =>
             defaultMessageGenerator.getNoFailingInstanceMessage,
         getVisualHelperToggle: props => <AutomatedChecksVisualizationToggle {...props} />,

--- a/src/assessments/types/iassessment.ts
+++ b/src/assessments/types/iassessment.ts
@@ -23,6 +23,7 @@ interface BaseAssessment {
     extensions?: AnyExtension[];
     initialDataCreator?: InitialDataCreator;
     isNonCollapsible?: boolean;
+    isEnabled?: boolean;
 }
 
 export interface ManualAssessment extends BaseAssessment {}

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -3,6 +3,7 @@
 import { UnhandledBrowserMessageResponse } from 'common/browser-adapters/browser-message-handler';
 export interface Message {
     messageType: string;
+    tabId?: number;
     payload?: any;
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,6 @@
         "stripInternal": true,
         "noEmitOnError": true,
         "skipLibCheck": true,
-        "suppressExcessPropertyErrors": true,
         "alwaysStrict": true,
         "noImplicitUseStrict": false,
         "moduleResolution": "node",


### PR DESCRIPTION
#### Details

TypeScript 5 deprecates the `suppressExcessPropertyErrors` flag. This is just a test to assess if it changes anything in our current code base.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
