### PR TITLE
chore: clean up references to MV2 background page

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ The Popup View is implemented in [`/src/popup/`](../src/popup/). Its entry point
 
 #### Background Service Worker
 
-The Background Service Worker (often abbreviated as just "background") is an an [extension service worker](https://developer.chrome.com/docs/extensions/mv3/service_workers/) which acts as the central controller for all of the extension's shared state and different contexts. It is where most "business logic" lives. Unlike all the other contexts, there is only ever one active service worker, no matter how many target pages a user might be working with at a time.
+The Background Service Worker (often abbreviated as just "background") is an [extension service worker](https://developer.chrome.com/docs/extensions/mv3/service_workers/) which acts as the central controller for all of the extension's shared state and different contexts. It is where most "business logic" lives. Unlike all the other contexts, there is only ever one active service worker, no matter how many target pages a user might be working with at a time.
 
 The Background Service Worker is implemented in [`/src/background/`](../src/background). Its entry point is [`/src/background/service-worker-init.ts`](../src/background/service-worker-init.ts).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,10 @@ A Target Page is a page being tested by the extension. When Accessibility Insigh
 
 ![Screenshot of target page with visualizations](./screenshots/target-page.png)
 
+Several Target Pages may have active Content Scripts at a time, and a single Target Page may have multiple active Content Scripts if it uses iframes.
+
+Generally, only the Content Script for a given Target Page's *topmost* frame communicates directly with [Flux messages and stores](#flux) from the Background Service Worker; instructions for child iframes' Content Scripts get passed down from their parent frame's Content Script via the different Frame Messenger components in [`/src/injected/frameCommunicators/`](../src/injected/frameCommunicators/).
+
 The injected Content Script is implemented in [`/src/injected/`](../src/injected/). Its entry point is [`/src/injected/window-initializer.ts`](../src/injected/window-initializer.ts).
 
 #### Popup
@@ -48,7 +52,7 @@ The Popup View is implemented in [`/src/popup/`](../src/popup/). Its entry point
 
 #### Background Service Worker
 
-The Background Service Worker (often abbreviated in the codebase as just "background") is an an [extension service worker](https://developer.chrome.com/docs/extensions/mv3/service_workers/) which acts as the central controller for all of the extension's shared state and different contexts. It is where most "business logic" lives. Unlike all the other contexts, there is only ever one active service worker, no matter how many target pages a user might be working with at a time.
+The Background Service Worker (often abbreviated as just "background") is an an [extension service worker](https://developer.chrome.com/docs/extensions/mv3/service_workers/) which acts as the central controller for all of the extension's shared state and different contexts. It is where most "business logic" lives. Unlike all the other contexts, there is only ever one active service worker, no matter how many target pages a user might be working with at a time.
 
 The Background Service Worker is implemented in [`/src/background/`](../src/background). Its entry point is [`/src/background/service-worker-init.ts`](../src/background/service-worker-init.ts).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ A Target Page is a page being tested by the extension. When Accessibility Insigh
 
 Several Target Pages may have active Content Scripts at a time, and a single Target Page may have multiple active Content Scripts if it uses iframes.
 
-Generally, only the Content Script for a given Target Page's *topmost* frame communicates directly with [Flux messages and stores](#flux) from the Background Service Worker; instructions for child iframes' Content Scripts get passed down from their parent frame's Content Script via the different Frame Messenger components in [`/src/injected/frameCommunicators/`](../src/injected/frameCommunicators/).
+Generally, only the Content Script for a given Target Page's *topmost* frame communicates directly with [Flux messages and stores](#flux) from the Background Service Worker. Instructions for child iframes' Content Scripts get passed down from their parent frame's Content Script via the different Frame Messenger components in [`/src/injected/frameCommunicators/`](../src/injected/frameCommunicators/).
 
 The injected Content Script is implemented in [`/src/injected/`](../src/injected/). Its entry point is [`/src/injected/window-initializer.ts`](../src/injected/window-initializer.ts).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,39 +3,54 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 -->
 
-## Accessibility Insights Extension Architecture
+## Accessibility Insights for Web Architecture
 
-This document describes the top level architecture for the Accessibility Insights extension. It was written after completing the transition from Chrome's [manifest v2](https://developer.chrome.com/docs/extensions/mv2/) to [manifest v3](https://developer.chrome.com/docs/extensions/mv3/), and as a result it highlights the changes made during that transition.
+This document describes the top level architecture for the Accessibility Insights for Web browser extension. It will be helpful to familiarize yourself with some of [the general concepts of browser extensions](https://developer.chrome.com/docs/extensions/mv3/getstarted/extensions-101/) before diving too deeply into this document.
 
 ### Extension Contexts
 
-At a top level, the extension has 4 main pages/operating contexts. These separate environments behave like a single flux application, as described [in the flux section](#flux).
+Accessibility Insights for Web runs in several different pages/operating contexts that communicate between one another. The major types of context are:
 
-In addition to these 4 main pages, the extension has 2 additional contexts targeted towards developers debugging the application, those being DevTools and DebugTools. 
+* The [Details View](#details-view), the main UI page that users interact with
+* The [Target Page](#target-page), the page that is being scanned/tested
+* The [Popup](#popup), the UI that pops up when selecting the extension icon near the browser address bar
+* The [Background Service Worker](#background-service-worker), which coordinates all the shared state for all the other contexts
+
+There may be multiple copies of each type of context at once, except for the Background Service Worker, which there is only one of active at a time.
+
+All of these separate environments behave like a single application, coordinated by the Background Service Worker. They coordinate state with one another using a [Flux design pattern](#flux).
 
 #### Details View
 
-A tab/page that is managed by the extension and utilized when we surface detailed results or information to the user. This view is linked to a specific target page through a tab id reference.
+The Details View is the main UI view for Accessibility Insights. It is where FastPass, Quick Assess, and Assessments are all displayed.
 
 ![Screenshot of details view](./screenshots/details-view.png)
 
+Each Details View corresponds to exactly one [Target Page](#target-page) at a time. This mapping is controlled by the `tabId` query parameter that is passed when other extension contexts first open the details view. It is possible for multiple Details Views to be open at a time.
+
+The Details View is implemented in [`/src/DetailsView/`](../src/DetailsView/). Its entry point is [`/src/DetailsView/details-view-initializer.ts`](../src/DetailsView/details-view-initializer.ts).
+
 #### Target Page
 
-This is the page being tested by the extension. The extension injects content scripts into the target page to do things like run axe-core to gather test results and display visualizations.
+A Target Page is a page being tested by the extension. When Accessibility Insights goes to scan a page, it does so by injecting a [Content Script](https://developer.chrome.com/docs/extensions/mv3/content_scripts/) into *each frame* of the Target Page. The Content Script is responsible for running `axe-core` scans and rendering in-page visualizations.
 
 ![Screenshot of target page with visualizations](./screenshots/target-page.png)
 
+The injected Content Script is implemented in [`/src/injected/`](../src/injected/). Its entry point is [`/src/injected/window-initializer.ts`](../src/injected/window-initializer.ts).
+
 #### Popup
 
-The page/javascript thread that is opened when the extension is activated.
+The Popup View is an extension page displayed in [a special browser-controlled window](https://developer.chrome.com/docs/extensions/mv3/user_interface/#popup) which appears a user clicks the extension's icon near the browser address bar.
 
 ![Screenshot of popup](./screenshots/popup.png)
 
-#### Background/Service Worker
+The Popup View is implemented in [`/src/popup/`](../src/popup/). Its entry point is [`/src/popup/popup-init.ts`](../src/popup/popup-init.ts).
 
-A javascript thread that runs for the extension outside of the scope of any specific tab. With manifest v2, this thread was called a [background page or background script](https://developer.chrome.com/docs/extensions/mv2/background_pages/). It was persistent, always available, and considered the singular 'source of truth' for the whole system. With manifest v3, background pages were replaced by [service workers](https://developer.chrome.com/docs/workbox/service-worker-overview/), the main difference being that service workers have finite lifetimes and shut down once the extension goes idle after a certain timeout. Importantly, both background pages and service workers only have single instances and have a 1:many relationship with tab contexts they manage.
+#### Background Service Worker
 
-During the transition from manifest v2 to v3, the background script was migrated to be run as a service worker. As a result, many of the uses of `background` in the code/file names in this repo are analogous with `service worker` for the mv3 extension.
+The Background Service Worker (often abbreviated in the codebase as just "background") is an an [extension service worker](https://developer.chrome.com/docs/extensions/mv3/service_workers/) which acts as the central controller for all of the extension's shared state and different contexts. It is where most "business logic" lives. Unlike all the other contexts, there is only ever one active service worker, no matter how many target pages a user might be working with at a time.
+
+The Background Service Worker is implemented in [`/src/background/`](../src/background). Its entry point is [`/src/background/service-worker-init.ts`](../src/background/service-worker-init.ts).
 
 ### Flux
 
@@ -43,10 +58,8 @@ The separate extension contexts communicate via [message passing](https://develo
 
 In this repo, message-creators, contained in [the message-creators directory](../src/common/message-creators), use messages to emulate actions. These messages are sent to the background/service worker where they are [distributed](../src/background/background-message-distributor.ts) to the specified context (i.e. a context for the specified tab or depending on the action, the global context). From there, the [interpreter](../src/background/interpreter.ts) will map the  message to an action-creator responsible for invoking the appropriate actions and thus causing stores to update. Once a store is updated, we broadcast the new state to other contexts (i.e. popup, details view, etc.) where a [store-proxy](../src/common/store-proxy.ts), emulating the respective store which was updated, receives the update and is used to populate the view. You can find the top level action interfaces/logic in [the flux directory](../src/common/flux) and stores in [the stores directory](../src/background/stores).
 
-Prior to manifest v3 changes, most of the flux actions were fire-and-forget, meaning we treated all action listeners as synchronous, even if they kicked off async work, as seen with the [sync-action class](../src/common/flux/sync-action.ts). This was fine with manifest v2's persistent background pages, but became a problem with manifest v3 service workers. Since service workers can be shut down when the browser thinks they have gone idle, it is important to track any outstanding work in the form of promises so that the browser is aware when there are unsettled promises still in progress and does not shut the service worker down prematurely. As a result, we switched any actions whose listeners kick off async work to be  [async-actions](../src/common/flux/async-action.ts). With this change, we are able to track outstanding work via promises, ensuring that the service worker stays active until all promises are settled.
-
 ### Storage
 
-With manifest v3, stores are maintained in the service worker. To ensure that data is not lost on service worker shut down and restart, the extension backs up necessary data in the browser's [IndexedDB API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), a persistent storage system. The logic for persisting and updating store data can be found in the [persistent-store class](../src/common/flux/persistent-store.ts) and the logic for fetching data on service worker start up can be found in [get-persisted-data](../src/background/get-persisted-data.ts). In addition to any stores that inherit from the persistent-store class, the data stored in the IndexedDB includes a few data structures containing metadata about the state of the extension in case the service worker is shut down while testing is still in progress.
+Stores are maintained in the Background Service Worker. To ensure that data is not lost on service worker shut down and restart, the extension backs up necessary data in the browser's [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API), a persistent storage system. The logic for persisting and updating store data can be found in the [persistent-store class](../src/common/flux/persistent-store.ts) and the logic for fetching data on service worker start up can be found in [get-persisted-data](../src/background/get-persisted-data.ts). In addition to any stores that inherit from the persistent-store class, the data stored in the IndexedDB includes a few data structures containing metadata about the state of the extension in case the service worker is shut down while testing is still in progress.
 
 **Note**: Because store data is persisted in the browser across extension runs/updates, it is important to consider backwards compatibility when updating any data structures in the [store-data directory](../src/common/types/store-data).

--- a/src/injected/extension-disabled-monitor.ts
+++ b/src/injected/extension-disabled-monitor.ts
@@ -10,7 +10,7 @@ import { PromiseFactory } from 'common/promises/promise-factory';
 // * User disabled the extension in the "Manage Extensions" settings page
 // * Extension is updated
 //
-// When this occurs, background pages/service workers get torn down, but
+// When this occurs, background service workers get torn down, but
 // already-injected content scripts don't; they remain active on the page
 // indefinitely, but lose the ability to communicate with other extension
 // pages.

--- a/src/injected/frameCommunicators/browser-backchannel-window-message-poster.ts
+++ b/src/injected/frameCommunicators/browser-backchannel-window-message-poster.ts
@@ -54,8 +54,8 @@ export class BrowserBackchannelWindowMessagePoster implements WindowMessagePoste
     }
 
     // The received message only contains an opaque ID. This callback uses that ID to ask the
-    // background page (our "backchannel") what the true message content is, then forwards the
-    // true content along to the previously-added listeners.
+    // background service worker (our "backchannel") what the true message content is, then forwards
+    // the true content along to the previously-added listeners.
     private onWindowMessageEvent = async (windowMessageEvent: MessageEvent<any>): Promise<void> => {
         // We know that source is a Window because we only register this handler via
         // window.addEventListener

--- a/src/tests/end-to-end/common/browser-factory.ts
+++ b/src/tests/end-to-end/common/browser-factory.ts
@@ -59,9 +59,9 @@ export async function launchBrowser(extensionOptions: ExtensionOptions): Promise
 
     const browser = new Browser(browserInstanceId, playwrightContext, onCloseCallback);
 
-    const backgroundPage = await browser.background();
+    const background = await browser.background();
     if (extensionOptions.suppressFirstTimeDialog) {
-        await backgroundPage.setTelemetryState(false);
+        await background.setTelemetryState(false);
     }
 
     return browser;

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -178,8 +178,8 @@ export class Browser {
     }
 
     public async setHighContrastMode(highContrastMode: boolean): Promise<void> {
-        const backgroundPage = await this.background();
-        await backgroundPage.setHighContrastMode(highContrastMode);
+        const background = await this.background();
+        await background.setHighContrastMode(highContrastMode);
     }
 
     private async setupDetailsViewAndTargetPage(
@@ -197,17 +197,17 @@ export class Browser {
     }
 
     private async getActivePageTabId(): Promise<number> {
-        const backgroundPage = await this.background();
+        const background = await this.background();
 
         // Check chrome.tabs is initialized
         const checkTabsInit = async () => {
-            while (await backgroundPage.evaluate(() => chrome.tabs == null, null)) {
+            while (await background.evaluate(() => chrome.tabs == null, null)) {
                 await setTimeout(50);
             }
         };
         await this.promiseFactory.timeout(checkTabsInit(), DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS);
 
-        return await backgroundPage.evaluate(() => {
+        return await background.evaluate(() => {
             return new Promise(resolve => {
                 chrome.tabs.query({ active: true, currentWindow: true }, tabs =>
                     resolve(tabs[0].id),
@@ -263,8 +263,8 @@ export class Browser {
     }
 
     private async getExtensionUrl(relativePath: string): Promise<string> {
-        const backgroundPage = await this.background();
-        const pageUrl = backgroundPage.url();
+        const background = await this.background();
+        const pageUrl = background.url();
 
         // pageUrl.origin would be correct here, but it doesn't get populated correctly in all node.js versions we build
         return `${pageUrl.protocol}//${pageUrl.host}/${relativePath}`;

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -139,7 +139,7 @@ export class Page extends Context {
     public url(): URL {
         // We use mainFrame().url() instead of just url() here because:
         // * They ought to be equivalent in every case we care to test
-        // * There is at least one edge case (the background page) where we've seen puppeteer
+        // * There is at least one edge case (the background worker) where we've seen puppeteer
         //   mis-populating url() but not target().url() as ':', and we don't know that Playwright
         //   fixed that.
         return new URL(this.underlyingPage.mainFrame().url());

--- a/src/tests/end-to-end/tests/details-view/instructions.test.ts
+++ b/src/tests/end-to-end/tests/details-view/instructions.test.ts
@@ -11,7 +11,7 @@ import { DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS } from '../../common/timeouts';
 describe('Details View -> Quick Assess -> Instructions', () => {
     let browser: Browser;
     let instructionsPage: DetailsViewPage;
-    let backgroundPage: BackgroundContext;
+    let backgroundContext: BackgroundContext;
 
     beforeAll(async () => {
         browser = await launchBrowser({
@@ -19,8 +19,8 @@ describe('Details View -> Quick Assess -> Instructions', () => {
             addExtraPermissionsToManifest: 'fake-activeTab',
         });
 
-        backgroundPage = await browser.background();
-        await backgroundPage.enableFeatureFlag('quickAssess');
+        backgroundContext = await browser.background();
+        await backgroundContext.enableFeatureFlag('quickAssess');
         instructionsPage = (await browser.newQuickAssess()).detailsViewPage;
     });
 

--- a/src/tests/end-to-end/tests/details-view/overview.test.ts
+++ b/src/tests/end-to-end/tests/details-view/overview.test.ts
@@ -13,14 +13,14 @@ describe('Details View -> Overview Page', () => {
     let targetPage: TargetPage;
     let overviewPage: DetailsViewPage;
     let loadAssessmentCount: number = 0;
-    let backgroundPage: BackgroundContext;
+    let backgroundContext: BackgroundContext;
 
     beforeAll(async () => {
         browser = await launchBrowser({ suppressFirstTimeDialog: true });
         targetPage = await browser.newTargetPage();
         await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
         overviewPage = await openOverviewPage(browser, targetPage);
-        backgroundPage = await browser.background();
+        backgroundContext = await browser.background();
     });
 
     afterAll(async () => {
@@ -139,8 +139,8 @@ describe('Details View -> Overview Page', () => {
         'should show correct number of items in export dropdown menu with codepen feature flag = %s',
         async codepenFlag => {
             codepenFlag
-                ? await backgroundPage.enableFeatureFlag('exportReportOptions')
-                : await backgroundPage.disableFeatureFlag('exportReportOptions');
+                ? await backgroundContext.enableFeatureFlag('exportReportOptions')
+                : await backgroundContext.disableFeatureFlag('exportReportOptions');
 
             await overviewPage.openExportDropdown();
             const items = (await overviewPage.countMenuItems()).valueOf();

--- a/src/tests/end-to-end/tests/details-view/quick-assess.test.ts
+++ b/src/tests/end-to-end/tests/details-view/quick-assess.test.ts
@@ -18,7 +18,7 @@ describe('Quick Assess', () => {
     let browser: Browser;
     let targetPage: TargetPage;
     let detailsViewPage: DetailsViewPage;
-    let backgroundPage: BackgroundContext;
+    let backgroundContext: BackgroundContext;
 
     describe('transfer to assessment dialog', () => {
         beforeAll(async () => {
@@ -30,8 +30,8 @@ describe('Quick Assess', () => {
                 testResourcePath: 'native-widgets/input-type-radio.html', // does not have any images, so will pass
             });
             await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
-            backgroundPage = await browser.background();
-            await backgroundPage.enableFeatureFlag('quickAssess');
+            backgroundContext = await browser.background();
+            await backgroundContext.enableFeatureFlag('quickAssess');
             detailsViewPage = await openOverviewPage(browser, targetPage);
             await detailsViewPage.navigateToRequirement('Image function');
             await detailsViewPage.waitForRequirementStatus('Image function', '4', 'Passed', {
@@ -75,8 +75,8 @@ describe('Quick Assess', () => {
                 testResourcePath: 'native-widgets/input-type-radio.html', // does not have any images, so will pass
             });
             await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
-            backgroundPage = await browser.background();
-            await backgroundPage.enableFeatureFlag('quickAssess');
+            backgroundContext = await browser.background();
+            await backgroundContext.enableFeatureFlag('quickAssess');
             detailsViewPage = await openOverviewPage(browser, targetPage);
             await detailsViewPage.navigateToRequirement('Image function');
             await detailsViewPage.waitForRequirementStatus('Image function', '4', 'Passed', {

--- a/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow-ui.test.ts
@@ -22,7 +22,7 @@ describe('Details View ->', () => {
     let detailsViewPage: DetailsViewPage;
     const height = 400;
     const narrowModeThresholds = getNarrowModeThresholdsForWeb();
-    let backgroundPage: BackgroundContext;
+    let backgroundContext: BackgroundContext;
 
     beforeAll(async () => {
         browser = await launchBrowser({
@@ -86,8 +86,8 @@ describe('Details View ->', () => {
 
     describe('Quick Assess -> Reflow', () => {
         beforeAll(async () => {
-            backgroundPage = await browser.background();
-            await backgroundPage.enableFeatureFlag('quickAssess');
+            backgroundContext = await browser.background();
+            await backgroundContext.enableFeatureFlag('quickAssess');
             detailsViewPage = (await browser.newQuickAssess()).detailsViewPage;
         });
 

--- a/src/tests/end-to-end/tests/details-view/reflow.test.ts
+++ b/src/tests/end-to-end/tests/details-view/reflow.test.ts
@@ -10,7 +10,7 @@ import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-
 describe('Details View -> Quick Assess -> Reflow', () => {
     let browser: Browser;
     let reflowPage: DetailsViewPage;
-    let backgroundPage: BackgroundContext;
+    let backgroundContext: BackgroundContext;
 
     beforeAll(async () => {
         browser = await launchBrowser({
@@ -18,8 +18,8 @@ describe('Details View -> Quick Assess -> Reflow', () => {
             addExtraPermissionsToManifest: 'fake-activeTab',
         });
 
-        backgroundPage = await browser.background();
-        await backgroundPage.enableFeatureFlag('quickAssess');
+        backgroundContext = await browser.background();
+        await backgroundContext.enableFeatureFlag('quickAssess');
         reflowPage = (await browser.newQuickAssess()).detailsViewPage;
     });
 

--- a/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
+++ b/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
@@ -13,13 +13,13 @@ describe('Details View -> Settings Panel', () => {
     let browser: Browser;
     let targetPage: TargetPage;
     let detailsViewPage: DetailsViewPage;
-    let backgroundPage: BackgroundContext;
+    let backgroundContext: BackgroundContext;
 
     beforeAll(async () => {
         browser = await launchBrowser({ suppressFirstTimeDialog: true });
         targetPage = await browser.newTargetPage();
         await browser.newPopupPage(targetPage);
-        backgroundPage = await browser.background();
+        backgroundContext = await browser.background();
         detailsViewPage = await browser.newDetailsViewPage(targetPage);
         await detailsViewPage.openSettingsPanel();
     });
@@ -36,14 +36,14 @@ describe('Details View -> Settings Panel', () => {
             );
         });
 
-        it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
-            await backgroundPage.setTelemetryState(true);
+        it('should reflect the state applied via the background service worker insightsUserConfiguration controller all other tests use', async () => {
+            await backgroundContext.setTelemetryState(true);
             await detailsViewPage.expectToggleState(
                 settingsPanelSelectors.telemetryStateToggle,
                 true,
             );
 
-            await backgroundPage.setTelemetryState(false);
+            await backgroundContext.setTelemetryState(false);
             await detailsViewPage.expectToggleState(
                 settingsPanelSelectors.telemetryStateToggle,
                 false,
@@ -75,14 +75,14 @@ describe('Details View -> Settings Panel', () => {
             );
         });
 
-        it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
-            await backgroundPage.setHighContrastMode(true);
+        it('should reflect the state applied via the background service worker insightsUserConfiguration controller all other tests use', async () => {
+            await backgroundContext.setHighContrastMode(true);
             await detailsViewPage.expectToggleState(
                 settingsPanelSelectors.highContrastModeToggle,
                 true,
             );
 
-            await backgroundPage.setHighContrastMode(false);
+            await backgroundContext.setHighContrastMode(false);
             await detailsViewPage.expectToggleState(
                 settingsPanelSelectors.highContrastModeToggle,
                 false,
@@ -93,7 +93,7 @@ describe('Details View -> Settings Panel', () => {
     it.each([true, false])(
         'should pass accessibility validation with highContrastMode=%s',
         async highContrastMode => {
-            await backgroundPage.setHighContrastMode(highContrastMode);
+            await backgroundContext.setHighContrastMode(highContrastMode);
             await detailsViewPage.waitForHighContrastMode(highContrastMode);
 
             const results = await scanForAccessibilityIssues(

--- a/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
+++ b/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
@@ -27,10 +27,10 @@ describe('Popup -> Hamburger menu', () => {
     it.each([true, false])(
         'should have content matching snapshot when quickAssess feature flag is %s',
         async quickAssessFeatureFlag => {
-            const backgroundPage = await browser.background();
+            const backgroundContext = await browser.background();
             quickAssessFeatureFlag === true
-                ? await backgroundPage.enableFeatureFlag('quickAssess')
-                : await backgroundPage.disableFeatureFlag('quickAssess');
+                ? await backgroundContext.enableFeatureFlag('quickAssess')
+                : await backgroundContext.disableFeatureFlag('quickAssess');
             const button = await popupPage.getSelectorElement(
                 popupPageElementIdentifiers.hamburgerMenuButton,
             );
@@ -56,10 +56,10 @@ describe('Popup -> Hamburger menu', () => {
         'should pass accessibility validation with highContrastMode=%s and quickAssessFeatureFlag=%s',
         async ({ highContrastMode, quickAssessFeatureFlag }) => {
             await browser.setHighContrastMode(highContrastMode);
-            const backgroundPage = await browser.background();
+            const backgroundContext = await browser.background();
             quickAssessFeatureFlag === true
-                ? await backgroundPage.enableFeatureFlag('quickAssess')
-                : await backgroundPage.disableFeatureFlag('quickAssess');
+                ? await backgroundContext.enableFeatureFlag('quickAssess')
+                : await backgroundContext.disableFeatureFlag('quickAssess');
             await popupPage.waitForHighContrastMode(highContrastMode);
 
             const button = await popupPage.getSelectorElement(

--- a/src/tests/end-to-end/tests/popup/launchpad.test.ts
+++ b/src/tests/end-to-end/tests/popup/launchpad.test.ts
@@ -27,10 +27,10 @@ describe('Popup -> Launch Pad', () => {
     it.each([true, false])(
         'content should match snapshot when quick assess feature flag is %s',
         async quickAssessFeatureFlag => {
-            const backgroundPage = await browser.background();
+            const backgroundContext = await browser.background();
             quickAssessFeatureFlag === true
-                ? await backgroundPage.enableFeatureFlag('quickAssess')
-                : await backgroundPage.disableFeatureFlag('quickAssess');
+                ? await backgroundContext.enableFeatureFlag('quickAssess')
+                : await backgroundContext.disableFeatureFlag('quickAssess');
             const element = await formatPageElementForSnapshot(
                 popupPage,
                 popupPageElementIdentifiers.launchPad,
@@ -48,10 +48,10 @@ describe('Popup -> Launch Pad', () => {
     `(
         'should pass accessibility validation with highContrastMode=%s and quickAssessFeatureFlag=%s',
         async ({ highContrastMode, quickAssessFeatureFlag }) => {
-            const backgroundPage = await browser.background();
+            const backgroundContext = await browser.background();
             quickAssessFeatureFlag === true
-                ? await backgroundPage.enableFeatureFlag('quickAssess')
-                : await backgroundPage.disableFeatureFlag('quickAssess');
+                ? await backgroundContext.enableFeatureFlag('quickAssess')
+                : await backgroundContext.disableFeatureFlag('quickAssess');
             await browser.setHighContrastMode(highContrastMode);
             await popupPage.waitForHighContrastMode(highContrastMode);
 


### PR DESCRIPTION
#### Details

This PR cleans up the Architecture document and a few lingering references to the term "Background Page" to make it more accessible for new folks learning about the codebase, for whom the current state of the architecture is much more important than the history of changes to the architecture.

##### Motivation

Make it easier for folks to learn/onboard to the codebase, remove some old terminology to avoid confusion.

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
