### PR TITLE
fix: update assessment reflow guidance clarifying use of 400% zoom

### DIFF
--- a/src/assessments/adaptable-content/test-steps/reflow.tsx
+++ b/src/assessments/adaptable-content/test-steps/reflow.tsx
@@ -27,7 +27,7 @@ const reflowHowToTest: JSX.Element = (
                     <li>
                         <Markup.Emphasis>
                             Note: 320 x 256 is equivalent to a display resolution of 1280 x 1024 at
-                            a 400% zoom
+                            a 400% zoom with the browser set to full screen mode.
                         </Markup.Emphasis>
                     </li>
                 </ul>

--- a/src/assessments/adaptable-content/test-steps/reflow.tsx
+++ b/src/assessments/adaptable-content/test-steps/reflow.tsx
@@ -22,12 +22,13 @@ const reflowHowToTest: JSX.Element = (
                 Use your system's display settings to set the display resolution to 1280 x 1024.
             </li>
             <li>
-                Use your browser's settings to set the target page's zoom to 400%.
+                Use your browser's settings to set the target page's zoom to 400% and to enable
+                full-screen mode.
                 <ul>
                     <li>
                         <Markup.Emphasis>
                             Note: 320 x 256 is equivalent to a display resolution of 1280 x 1024 at
-                            a 400% zoom with the browser set to full screen mode.
+                            a 400% zoom with the browser set to full-screen mode.
                         </Markup.Emphasis>
                     </li>
                 </ul>


### PR DESCRIPTION
#### Details

This PR fixes the Reflow assessment guidance to clarify if/when 320 x 256 is equivalent to 1280 x 1024 at 400% zoom, per suggestion in our internal docs repo (1554) by @scottaohara.

![screenshot showing new text inline as part of reflow guidance](https://github.com/microsoft/accessibility-insights-web/assets/376284/d17fc3d4-c7fc-4e80-a04c-47386a41e73f)

##### Motivation

Make assessment guidance more accurate

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: docs 1554
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
