### PR TITLE
chore: add new chrome refresh token script to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -48,5 +48,6 @@ test-results/
 yarn.lock
 src/DetailsView/components/generated-validate-assessment-json.js
 replace-plugin.js
+tools/get-chrome-web-store-refresh-token.ps1
 
 .ignoredRevs


### PR DESCRIPTION
#### Details

This adds `tools/get-chrome-web-store-refresh-token.ps1` to `.prettierignore` so our linting scripts that use prettier can run without errors.

##### Motivation

`yarn fastpass` should run without errors


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
