### PR TITLE
chore: Increase dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,7 @@ updates:
     prefix: chore
     include: scope
   versioning-strategy: increase
+  open-pull-requests-limit: 10 # Default value of 5 has been problematic
   ignore:
     # axe-core updates require enough extra validation
     # on false positives and breaking ai-web, so avoiding


### PR DESCRIPTION
#### Details

Increase dependabot PR limit from the default of 5. We've seen cases where our updates get blocked behind dependabot PR's that contain breaking changes. Since we're scheduled to run dependabot once per day, we end up accumulating updates without realizing it.

##### Motivation

Updates shouldn't hide in the dependabot queue.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
