### PR TITLE
chore: have dependabot ignore updates from @fluentui/react until we find a solution for enzyme

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,10 +56,11 @@ updates:
   - dependency-name: "@types/node"
     versions:
     - ">=15.0.0"
-    # Major version upgrades of fluentui will require extra validation
+    # Ignore fluentui/react updates until we come up with a solution for either
+    # working with enzyme or replacing it
   - dependency-name: "@fluentui/react"
     versions:
-    - ">= 9.0.0"
+    - ">= 0"
     # Keeping react at 16 due to compatibility issues with enzyme
     # Upgrade tracked by https://mseng.visualstudio.com/1ES/_workitems/edit/1914758
   - dependency-name: react

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,7 @@ updates:
     # working with enzyme or replacing it
   - dependency-name: "@fluentui/react"
     versions:
-    - ">= 0"
+    - ">= 8.96.1"
     # Keeping react at 16 due to compatibility issues with enzyme
     # Upgrade tracked by https://mseng.visualstudio.com/1ES/_workitems/edit/1914758
   - dependency-name: react


### PR DESCRIPTION
#### Details

Update `dependabot.yml` to ignore all updates from `@fluentui/react`

##### Motivation

Updates to `@fluentui/react` are blocked until we replace `enzyme`.

##### Context



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
