### PR TITLE
feat(remove-android): Remove Android telemetry types

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -119,8 +119,6 @@ export enum TelemetryEventSource {
     NewBugButton,
     TargetPage,
     ContentPage,
-    ElectronDeviceConnect,
-    ElectronResultsView,
     Background,
     PopUp,
     DevTools,
@@ -227,13 +225,6 @@ export type NeedsReviewAnalyzerScanTelemetryData = {
     incompleteRuleResults: string;
 } & RuleAnalyzerScanTelemetryData;
 
-export type AndroidScanStartedTelemetryData = {
-    source: TelemetryEventSource;
-};
-export type AndroidScanCompletedTelemetryData = {
-    scanDuration: number;
-} & InstanceCount;
-
 export type TabStopsAutomatedResultsTelemetryData = {
     tabStopAutomatedFailuresInstanceCount: TabStopAutomatedFailuresInstanceCount;
 } & BaseTelemetryData;
@@ -266,36 +257,12 @@ export type TabStopAutomatedFailuresInstanceCount = {
     [requirementId: string]: number;
 };
 
-export type AtfaInstanceCount = {
-    ERROR: {
-        [ruleId: string]: number;
-    };
-    WARNING: {
-        [ruleId: string]: number;
-    };
-    INFO: {
-        [ruleId: string]: number;
-    };
-    RESOLVED: {
-        [ruleId: string]: number;
-    };
-};
-
-export type AndroidScanFailedTelemetryData = {
-    port?: number;
-    scanDuration: number;
-};
-
 export type SetAllUrlsPermissionTelemetryData = {
     permissionState: boolean;
 } & BaseTelemetryData;
 
 export type ScanIncompleteWarningsTelemetryData = {
     scanIncompleteWarnings: ScanIncompleteWarningId[];
-};
-
-export type DeviceFocusKeyEventTelemetryData = {
-    keyEventCode: number;
 };
 
 export type AutoDetectedFailuresDialogStateTelemetryData = {
@@ -340,10 +307,6 @@ export type TelemetryData =
     | IssuesAnalyzerScanTelemetryData
     | AssessmentRequirementScanTelemetryData
     | RequirementStatusTelemetryData
-    | AndroidScanStartedTelemetryData
-    | AndroidScanCompletedTelemetryData
-    | AndroidScanFailedTelemetryData
-    | DeviceFocusKeyEventTelemetryData
     | ScanIncompleteWarningsTelemetryData
     | SetAllUrlsPermissionTelemetryData
     | TabStopsAutomatedResultsTelemetryData

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -19,6 +19,7 @@ import { GlobalActionCreator } from 'background/global-action-creators/global-ac
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import {
+    TelemetryData,
     TelemetryEventSource,
     TRANSFER_QUICK_ASSESS_DATA_TO_ASSESSMENT_INITIATED,
 } from 'common/extension-telemetry-events';
@@ -118,7 +119,7 @@ describe('GlobalActionCreatorTest', () => {
         const payload: BaseActionPayload = {
             telemetry: {
                 source: TelemetryEventSource.DetailsView,
-            },
+            } as TelemetryData,
         };
 
         const validator = new GlobalActionCreatorValidator()

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
@@ -3,15 +3,12 @@
 exports[`CollapsibleScriptProvider produces script source that matches snapshot 1`] = `
 "(function addEventListenerForCollapsibleSection(doc) {
   var _loop = function (index) {
-    var _container_querySelector, _this;
+    var _container;
     var container = collapsibles.item(index);
     var button =
-      (_this = container) === null || _this === void 0
+      (_container = container) === null || _container === void 0
         ? void 0
-        : (_container_querySelector = _this.querySelector) === null ||
-          _container_querySelector === void 0
-        ? void 0
-        : _container_querySelector.call(_this, ".collapsible-control");
+        : _container.querySelector(".collapsible-control");
     if (button == null) {
       return "continue";
     }

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
@@ -3,12 +3,15 @@
 exports[`CollapsibleScriptProvider produces script source that matches snapshot 1`] = `
 "(function addEventListenerForCollapsibleSection(doc) {
   var _loop = function (index) {
-    var _container;
+    var _container_querySelector, _this;
     var container = collapsibles.item(index);
     var button =
-      (_container = container) === null || _container === void 0
+      (_this = container) === null || _this === void 0
         ? void 0
-        : _container.querySelector(".collapsible-control");
+        : (_container_querySelector = _this.querySelector) === null ||
+          _container_querySelector === void 0
+        ? void 0
+        : _container_querySelector.call(_this, ".collapsible-control");
     if (button == null) {
       return "continue";
     }


### PR DESCRIPTION
#### Details

Deprecating Android support will touch hundreds of files, so we're breaking it up into more manageable units. This removes the telemetry types that were defined for Android. There was an intermediate commit that resulted from noise in generating a snapshot for a unit test. At first I thought it was a platform problem, but it may have been a caching issue. I'll open an issue if I can get a consistent repro, but it seems to be unrelated to this change.

##### Motivation

Android deprecation feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue (part of Android deprecation feature)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS