### PR TITLE
feat(remove-android): Odds and ends

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,12 +45,6 @@ updates:
   - dependency-name: axe-core
     versions:
     - ">= 0"
-    # All electron builds are going to be manually updated
-    # since our release builds use a non-standard Electron build
-    # with distribution-restricted media codecs stripped out
-  - dependency-name: electron
-    versions:
-    - ">= 0"
     # Major version of @types/node is pinned to match the version of node we
     # use for builds (ideally, latest LTS)
   - dependency-name: "@types/node"

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,8 +2,6 @@
 # Licensed under the MIT License.
 
 **/*.a11ywebassessment
-**/*.cs
-**/*.csproj
 **/*.dockerignore
 **/*.gitattributes
 **/*.gitignore
@@ -29,12 +27,10 @@
 .yarn/
 AppXManifest.xml
 copyright-header.txt
-bin/
 bundle/
 dist/
 docs/art/ada-cat.ansi256.txt
 docs/LICENSE.txt
-obj/
 src/NOTICE.html
 drop/
 extension/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -46,29 +46,6 @@
             "sourceMapPathOverrides": {
                 "webpack:///./*": "${workspaceFolder}/*"
             }
-        },
-        {
-            "name": "Debug electron main process with --remote-debugging-port=9222",
-            "type": "node",
-            "request": "launch",
-            "cwd": "${workspaceRoot}",
-            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-            "windows": {
-                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
-            },
-            "args": ["drop/electron/unified-dev/product/bundle/main.bundle.js"],
-            "runtimeArgs": ["--remote-debugging-port=9222"],
-            "outputCapture": "std"
-        },
-        {
-            "name": "Attach debugger to electron renderer process (must first launch main process with --remote-debugging-port=9222)",
-            "type": "chrome",
-            "request": "attach",
-            "port": 9222,
-            "webRoot": "${workspaceFolder}/drop/electron/unified-dev/product",
-            "sourceMapPathOverrides": {
-                "webpack:///./*": "${workspaceFolder}/*"
-            }
         }
     ],
     "inputs": [

--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -11,8 +11,6 @@
         "./dist",
         "./docs/art/ada-cat.ansi256.txt",
         "./docs/LICENSE.txt",
-        "./src/electron/resources/mit_license_en.txt",
-        "./src/electron/resources/mit_license.txt",
         "./drop",
         "./extension",
         "./node_modules",

--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -23,7 +23,6 @@
         ".gitattributes",
         ".ignoredRevs",
         "**/*.a11ywebassessment",
-        "**/*.csproj",
         "**/.DS_Store",
         "**/*.icns",
         "**/*.scss.d.ts",
@@ -32,10 +31,8 @@
         "**/*.svg",
         "**/*.mp3",
         "**/.vs",
-        "**/bin",
         "**/bundle",
         "**/drop",
-        "**/obj",
         "**/test-results",
         "**/yarn.lock",
         "Dockerfile",
@@ -54,7 +51,7 @@
             "prepend": "<!--",
             "append": "-->"
         },
-        "ts|tsx|d.ts|js|scss|css|cs": {
+        "ts|tsx|d.ts|js|scss|css": {
             "eachLine": {
                 "prepend": "// "
             }

--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -10,7 +10,6 @@ module.exports = function (grunt) {
 
     const options = {
         appInsightsInstrumentationKey: grunt.option('app-insights-instrumentation-key'),
-        electronUpdateURL: grunt.option('electron-update-url'),
         extensionVersion: grunt.option('extension-version'),
         webstoreAppId: grunt.option('webstore-app-id'),
     };

--- a/esbuild.js
+++ b/esbuild.js
@@ -12,12 +12,6 @@ const { CreateStylePlugin } = require('./style-plugin');
 const src = './src';
 const argsObj = yargs(argv).argv;
 
-const electronEntryFiles = {
-    renderer: [path.resolve(__dirname, 'src/electron/views/renderer-initializer.ts')],
-    main: [path.resolve(__dirname, 'src/electron/main/main.ts')],
-};
-const unifiedOutdir = path.join(__dirname, 'extension/unifiedBundle');
-
 const webExtensionEntryFiles = {
     injected: `${src}/injected/client-init.ts`,
     popup: `${src}/popup/popup-init.ts`,
@@ -83,15 +77,6 @@ let minify = false;
 let sourcemap = true;
 
 switch (argsObj.env) {
-    // Note: currently causes errors when electron app is run.
-    case 'unified':
-        entryFiles = electronEntryFiles;
-        outdir = unifiedOutdir;
-        platform = 'node';
-        external = [];
-        format = 'cjs';
-        break;
-
     case 'prod':
         minify = true;
         sourcemap = false;

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,5 @@ module.exports = {
         '<rootDir>/packages/*',
         '<rootDir>/src/tests/unit',
         '<rootDir>/src/tests/end-to-end',
-        '<rootDir>/src/tests/electron',
     ],
 };

--- a/src/reports/components/report-sections/fast-pass-report-automated-checks-results.tsx
+++ b/src/reports/components/report-sections/fast-pass-report-automated-checks-results.tsx
@@ -3,7 +3,6 @@
 
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
 import { NamedFC } from 'common/react/named-fc';
-import { _electron } from 'playwright';
 import * as React from 'react';
 import { FastPassReportProps } from 'reports/components/fast-pass-report';
 import { IncompleteChecksSection } from 'reports/components/report-sections/incomplete-checks-section';

--- a/src/reports/components/report-sections/fast-pass-report-automated-checks-results.tsx
+++ b/src/reports/components/report-sections/fast-pass-report-automated-checks-results.tsx
@@ -3,6 +3,7 @@
 
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
 import { NamedFC } from 'common/react/named-fc';
+import { _electron } from 'playwright';
 import * as React from 'react';
 import { FastPassReportProps } from 'reports/components/fast-pass-report';
 import { IncompleteChecksSection } from 'reports/components/report-sections/incomplete-checks-section';

--- a/targets.config.js
+++ b/targets.config.js
@@ -25,12 +25,6 @@ const commonExtensionOptions = {
     productCategory: 'extension',
 };
 
-const commonUnifiedOptions = {
-    fullName: 'Accessibility Insights for Android',
-    bundled: true,
-    productCategory: 'electron',
-};
-
 module.exports = {
     dev: {
         config: {
@@ -94,65 +88,5 @@ module.exports = {
         },
         bundleFolder: 'prodBundle',
         mustExistFile: 'serviceWorker.bundle.js',
-    },
-    'unified-dev': {
-        config: {
-            options: {
-                ...commonUnifiedOptions,
-                ...icons.dev,
-                fullName: 'Accessibility Insights for Android - Dev',
-                telemetryBuildName: 'AI Android - Dev',
-            },
-        },
-        bundleFolder: 'unifiedBundle',
-        mustExistFile: 'main.bundle.js',
-    },
-    'unified-canary': {
-        release: true,
-        config: {
-            options: {
-                ...commonUnifiedOptions,
-                ...icons.canary,
-                fullName: 'Accessibility Insights for Android - Canary',
-                telemetryBuildName: 'AI Android - Canary',
-            },
-        },
-        bundleFolder: 'unifiedBundle',
-        mustExistFile: 'main.bundle.js',
-        appId: 'com.microsoft.accessibilityinsights.unified.canary',
-        publishUrl: 'https://a11yunifiedcanaryblob.blob.core.windows.net/a11yunified-canary',
-        telemetryKeyIdentifier: 'unified-canary-instrumentation-key',
-    },
-    'unified-insider': {
-        release: true,
-        config: {
-            options: {
-                ...commonUnifiedOptions,
-                ...icons.insider,
-                fullName: 'Accessibility Insights for Android - Insider',
-                telemetryBuildName: 'AI Android - Insider',
-            },
-        },
-        bundleFolder: 'unifiedBundle',
-        mustExistFile: 'main.bundle.js',
-        appId: 'com.microsoft.accessibilityinsights.unified.insider',
-        publishUrl: 'https://a11yunifiedinsiderblob.blob.core.windows.net/a11yunified-insider',
-        telemetryKeyIdentifier: 'unified-insider-instrumentation-key',
-    },
-    'unified-production': {
-        release: true,
-        config: {
-            options: {
-                ...commonUnifiedOptions,
-                ...icons.production,
-                fullName: 'Accessibility Insights for Android',
-                telemetryBuildName: 'AI Android - Production',
-            },
-        },
-        bundleFolder: 'unifiedBundle',
-        mustExistFile: 'main.bundle.js',
-        appId: 'com.microsoft.accessibilityinsights.unified.production',
-        publishUrl: 'https://a11yunifiedprodblob.blob.core.windows.net/a11yunified-prod',
-        telemetryKeyIdentifier: 'unified-prod-instrumentation-key',
     },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,11 +26,6 @@ const commonEntryFiles = {
     debugTools: path.resolve(__dirname, 'src/debug-tools/initializer/debug-tools-init.tsx'),
 };
 
-const electronEntryFiles = {
-    renderer: [path.resolve(__dirname, 'src/electron/views/renderer-initializer.ts')],
-    main: [path.resolve(__dirname, 'src/electron/main/main.ts')],
-};
-
 const tsRule = {
     test: /\.tsx?$/,
     use: [
@@ -92,27 +87,6 @@ const commonConfig = {
     },
 };
 
-const unifiedConfig = {
-    ...commonConfig,
-    entry: electronEntryFiles,
-    name: 'unified',
-    mode: 'development',
-    devtool: 'source-map',
-    output: {
-        path: path.join(__dirname, 'extension/unifiedBundle'),
-        filename: '[name].bundle.js',
-    },
-    node: {
-        ...commonConfig.node,
-        __dirname: false,
-        __filename: false,
-    },
-    optimization: {
-        splitChunks: false,
-    },
-    target: 'electron-main',
-};
-
 const packageUIConfig = {
     entry: {
         ui: [path.resolve(__dirname, 'src/packages/accessibility-insights-ui/index.ts')],
@@ -134,5 +108,5 @@ const packageUIConfig = {
     target: 'node',
 };
 
-// For just one config, use "webpack --config-name unified", "webpack --config-name package-ui", etc
-module.exports = [unifiedConfig, packageUIConfig];
+// For just one config, use "webpack --config-name package-ui", etc
+module.exports = [packageUIConfig];


### PR DESCRIPTION
#### Details

This cleans up some odds and ends from removing Android:
- Remove C# file types from various exclusion lists (I intentionally left the `.vs` folder, since it was in the `.gitignore` file before it was added to `.prettierignore`
- Remove some scraps of the old unified building scripts (calls were already removed, but not the guts)
- Remove configs to debug unified app from inside vscode
- Remove dependabot policy for electron

##### Motivation

Android deprecation feature (this is potentially the last PR for this step)

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
There's a weird reference to `playwright` from inside main code. It feels like a bug, but since it's not part of the deprecation, I'll put it into a separate PR

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Android deprecation feature
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
