### PR TITLE
chore: Remove odd import

### DIFF
--- a/src/reports/components/report-sections/fast-pass-report-automated-checks-results.tsx
+++ b/src/reports/components/report-sections/fast-pass-report-automated-checks-results.tsx
@@ -3,7 +3,6 @@
 
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
 import { NamedFC } from 'common/react/named-fc';
-import { _electron } from 'playwright';
 import * as React from 'react';
 import { FastPassReportProps } from 'reports/components/fast-pass-report';
 import { IncompleteChecksSection } from 'reports/components/report-sections/incomplete-checks-section';


### PR DESCRIPTION
#### Details

The reports package contains an odd import that seems out of place because:
- It imports from the `playwright` package, which isn't a product dependency
- The imported variable of `_electron` is never used by the code
- Tests all pass when the import is removed

##### Motivation

Code hygiene

##### Context

I came across this during the Android deprecation. I searched for "electron" and this was the list remaining instance in the code. I kept it out of the Android cleanup PR since it wasn't directly connected. The line was added in #5048, where it seems to have slipped in accidentally. 

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
