### PR TITLE
fix: Improve tab stop instructions

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -84,7 +84,11 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                 <ol>
                     <li>
                         Use your keyboard to move input focus through all the interactive elements
-                        in the page:
+                        in the page--
+                        <Markup.Emphasis>
+                            please traverse the entire page before returning to this window
+                        </Markup.Emphasis>
+                        :
                         <ol>
                             <li>
                                 Use <Markup.Term>Tab</Markup.Term> and{' '}
@@ -108,12 +112,12 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                                 Select <Markup.Term>Pass</Markup.Term> if all instances meet the
                                 requirement.
                             </li>
-                            <li>
-                                <Markup.Emphasis>
-                                    Review any auto-discovered failures to be sure they are valid.
-                                </Markup.Emphasis>
-                            </li>
                         </ol>
+                    </li>
+                    <li>
+                        <Markup.Emphasis>
+                            Review any auto-discovered failures to be sure they are valid.
+                        </Markup.Emphasis>
                     </li>
                 </ol>
             </>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -35,7 +35,11 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
             </p>
             <ol>
               <li>
-                Use your keyboard to move input focus through all the interactive elements in the page:
+                Use your keyboard to move input focus through all the interactive elements in the page--
+                <Emphasis>
+                  please traverse the entire page before returning to this window
+                </Emphasis>
+                :
                 <ol>
                   <li>
                     Use 
@@ -72,12 +76,12 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
                     </Term>
                      if all instances meet the requirement.
                   </li>
-                  <li>
-                    <Emphasis>
-                      Review any auto-discovered failures to be sure they are valid.
-                    </Emphasis>
-                  </li>
                 </ol>
+              </li>
+              <li>
+                <Emphasis>
+                  Review any auto-discovered failures to be sure they are valid.
+                </Emphasis>
               </li>
             </ol>
           </React.Fragment>
@@ -171,7 +175,11 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
             </p>
             <ol>
               <li>
-                Use your keyboard to move input focus through all the interactive elements in the page:
+                Use your keyboard to move input focus through all the interactive elements in the page--
+                <Emphasis>
+                  please traverse the entire page before returning to this window
+                </Emphasis>
+                :
                 <ol>
                   <li>
                     Use 
@@ -208,12 +216,12 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
                     </Term>
                      if all instances meet the requirement.
                   </li>
-                  <li>
-                    <Emphasis>
-                      Review any auto-discovered failures to be sure they are valid.
-                    </Emphasis>
-                  </li>
                 </ol>
+              </li>
+              <li>
+                <Emphasis>
+                  Review any auto-discovered failures to be sure they are valid.
+                </Emphasis>
               </li>
             </ol>
           </React.Fragment>


### PR DESCRIPTION
#### Details

Issue #6625 was caused by the user interacting with the test in ways that confused the automatic checks. At a future point, we might revisit the automated checks workflow, but that's not currently in scope. Instead, we're updating the instructions to clarify the intended workflow, which is that the user should traverse the entire page with just the keyboard _before returning to the extension window_. The design team also asked us to promote step 2c (review the autodetected failures) to a top-level step.

##### Motivation

Addresses #6625

##### Screenshots

Before Change | After Change
--- | ---
<img width="533" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/01209e23-26fa-4039-bc42-aebfd55b4226"> | <img width="539" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/3ddcaebc-98e5-4a12-b99c-5c04988129fa">

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
