### PR TITLE
refactor: remove obsolete persistStoreData flag from PersistentStore, take 2

### DIFF
--- a/src/background/stores/assessment-card-selection-store.ts
+++ b/src/background/stores/assessment-card-selection-store.ts
@@ -45,11 +45,10 @@ export class AssessmentCardSelectionStore extends PersistentStore<AssessmentCard
         private readonly initialAssessmentStoreDataGenerator: InitialAssessmentStoreDataGenerator,
         idbInstance: IndexedDBAPI,
         logger: Logger,
-        persistStoreData: boolean,
         indexDBKey: string,
         storeName: StoreNames,
     ) {
-        super(storeName, persistedState, idbInstance, indexDBKey, logger, persistStoreData);
+        super(storeName, persistedState, idbInstance, indexDBKey, logger);
     }
 
     protected addActionListeners(): void {

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -62,7 +62,7 @@ export class AssessmentStore extends PersistentStore<AssessmentStoreData> {
         name: StoreNames,
         indexDBKey: string,
     ) {
-        super(name, persistedData, idbInstance, indexDBKey, logger, true);
+        super(name, persistedData, idbInstance, indexDBKey, logger);
     }
 
     protected override generateDefaultState(

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -35,7 +35,6 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
         private readonly convertResultsToCardSelectionStoreDataCallback: ConvertResultsToCardSelectionStoreDataCallback = convertResultsToCardSelectionStoreData,
         private readonly convertDataToScanNodeResults: ConvertUnifiedStoreDataToScanNodeResultsCallback = convertUnifiedStoreDataToScanNodeResults,
     ) {
@@ -45,7 +44,6 @@ export class CardSelectionStore extends PersistentStore<CardSelectionStoreData> 
             idbInstance,
             IndexedDBDataKeys.cardSelectionStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -26,7 +26,6 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.DetailsViewStore,
@@ -34,7 +33,6 @@ export class DetailsViewStore extends PersistentStore<DetailsViewStoreData> {
             idbInstance,
             IndexedDBDataKeys.detailsViewStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -17,7 +17,6 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.DevToolsStore,
@@ -25,7 +24,6 @@ export class DevToolStore extends PersistentStore<DevToolStoreData> {
             idbInstance,
             IndexedDBDataKeys.devToolStore(tabId),
             logger,
-            persistStoreData,
         );
 
         this.devToolActions = devToolActions;

--- a/src/background/stores/global/command-store.ts
+++ b/src/background/stores/global/command-store.ts
@@ -23,7 +23,6 @@ export class CommandStore extends PersistentStore<CommandStoreData> {
         persistedState: CommandStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.CommandStore,
@@ -31,7 +30,6 @@ export class CommandStore extends PersistentStore<CommandStoreData> {
             idbInstance,
             IndexedDBDataKeys.commandStore,
             logger,
-            persistStoreData,
         );
 
         this.commandActions = commandActions;

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -114,7 +114,6 @@ export class GlobalStoreHub implements StoreHub {
             new InitialAssessmentStoreDataGenerator(assessmentsProvider.all()),
             indexedDbInstance,
             logger,
-            persistStoreData,
             IndexedDBDataKeys.assessmentCardSelectionStore,
             StoreNames.AssessmentCardSelectionStore,
         );
@@ -127,7 +126,6 @@ export class GlobalStoreHub implements StoreHub {
             new InitialAssessmentStoreDataGenerator(quickAssessProvider.all()),
             indexedDbInstance,
             logger,
-            persistStoreData,
             IndexedDBDataKeys.quickAssessCardSelectionStore,
             StoreNames.QuickAssessCardSelectionStore,
         );

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -55,15 +55,12 @@ export class GlobalStoreHub implements StoreHub {
         storageAdapter: StorageAdapter,
         logger: Logger,
     ) {
-        const persistStoreData = true;
-
         this.commandStore = new CommandStore(
             globalActionHub.commandActions,
             telemetryEventHandler,
             persistedData.commandStoreData,
             indexedDbInstance,
             logger,
-            persistStoreData,
         );
         this.featureFlagStore = new FeatureFlagStore(
             globalActionHub.featureFlagActions,
@@ -81,7 +78,6 @@ export class GlobalStoreHub implements StoreHub {
             persistedData.scopingStoreData,
             indexedDbInstance,
             logger,
-            persistStoreData,
         );
         this.assessmentStore = new AssessmentStore(
             browserAdapter,
@@ -146,7 +142,6 @@ export class GlobalStoreHub implements StoreHub {
             persistedData.permissionsStateStoreData,
             indexedDbInstance,
             logger,
-            persistStoreData,
         );
         this.dataTransferStore = new DataTransferStore(globalActionHub.dataTransferActions);
     }

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -15,7 +15,6 @@ export class PermissionsStateStore extends PersistentStore<PermissionsStateStore
         protected readonly persistedState: PermissionsStateStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.PermissionsStateStore,
@@ -23,7 +22,6 @@ export class PermissionsStateStore extends PersistentStore<PermissionsStateStore
             idbInstance,
             IndexedDBDataKeys.permissionsStateStore,
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -19,7 +19,6 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
         persistedState: ScopingStoreData,
         idbInstance: IndexedDBAPI,
         logger: Logger,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.ScopingPanelStateStore,
@@ -27,7 +26,6 @@ export class ScopingStore extends PersistentStore<ScopingStoreData> {
             idbInstance,
             IndexedDBDataKeys.scopingStore,
             logger,
-            persistStoreData,
         );
 
         this.scopingActions = scopingActions;

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -42,7 +42,6 @@ export class UserConfigurationStore extends PersistentStore<UserConfigurationSto
             indexDbApi,
             IndexedDBDataKeys.userConfiguration,
             logger,
-            true,
         );
     }
 

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -21,7 +21,6 @@ export class InspectStore extends PersistentStore<InspectStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.InspectStore,
@@ -29,7 +28,6 @@ export class InspectStore extends PersistentStore<InspectStoreData> {
             idbInstance,
             IndexedDBDataKeys.inspectStore(tabId),
             logger,
-            persistStoreData,
         );
 
         this.inspectActions = inspectActions;

--- a/src/background/stores/needs-review-card-selection-store.ts
+++ b/src/background/stores/needs-review-card-selection-store.ts
@@ -33,7 +33,6 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
         private readonly convertResultsToCardSelectionStoreDataCallback: ConvertResultsToCardSelectionStoreDataCallback = convertResultsToCardSelectionStoreData,
         private readonly convertDataToScanNodeResults: ConvertUnifiedStoreDataToScanNodeResultsCallback = convertUnifiedStoreDataToScanNodeResults,
     ) {
@@ -43,7 +42,6 @@ export class NeedsReviewCardSelectionStore extends PersistentStore<NeedsReviewCa
             idbInstance,
             IndexedDBDataKeys.needsReviewCardSelectionStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/needs-review-scan-result-store.ts
+++ b/src/background/stores/needs-review-scan-result-store.ts
@@ -18,7 +18,6 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.NeedsReviewScanResultStore,
@@ -26,7 +25,6 @@ export class NeedsReviewScanResultStore extends PersistentStore<NeedsReviewScanR
             idbInstance,
             IndexedDBDataKeys.needsReviewScanResultsStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -15,7 +15,6 @@ export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.PathSnippetStore,
@@ -23,7 +22,6 @@ export class PathSnippetStore extends PersistentStore<PathSnippetStoreData> {
             idbInstance,
             IndexedDBDataKeys.pathSnippetStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -45,7 +45,6 @@ export class TabContextStoreHub implements StoreHub {
         tabId: number,
         urlParser: UrlParser,
     ) {
-        const persistStoreData = true;
         const persistedTabData = persistedData.tabData ? persistedData.tabData[tabId] : null;
 
         this.visualizationStore = new VisualizationStore(
@@ -57,7 +56,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
             new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
         );
         this.visualizationStore.initialize();
@@ -73,7 +71,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.visualizationScanResultStore.initialize();
 
@@ -84,7 +81,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
             urlParser,
         );
         this.tabStore.initialize();
@@ -95,7 +91,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.devToolStore.initialize();
 
@@ -107,7 +102,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.detailsViewStore.initialize();
 
@@ -118,7 +112,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.inspectStore.initialize();
 
@@ -128,7 +121,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.pathSnippetStore.initialize();
 
@@ -139,7 +131,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.unifiedScanResultStore.initialize();
 
@@ -151,7 +142,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.cardSelectionStore.initialize();
 
@@ -162,7 +152,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.needsReviewScanResultStore.initialize();
 
@@ -174,7 +163,6 @@ export class TabContextStoreHub implements StoreHub {
             indexedDBInstance,
             logger,
             tabId,
-            persistStoreData,
         );
         this.needsReviewCardSelectionStore.initialize();
     }

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -22,7 +22,6 @@ export class TabStore extends PersistentStore<TabStoreData> {
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
         private readonly urlParser: UrlParser,
     ) {
         super(
@@ -31,7 +30,6 @@ export class TabStore extends PersistentStore<TabStoreData> {
             idbInstance,
             IndexedDBDataKeys.tabStore(tabId),
             logger,
-            persistStoreData,
         );
 
         this.tabActions = tabActions;

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -18,7 +18,6 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.UnifiedScanResultStore,
@@ -26,7 +25,6 @@ export class UnifiedScanResultStore extends PersistentStore<UnifiedScanResultSto
             idbInstance,
             IndexedDBDataKeys.unifiedScanResultStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -48,7 +48,6 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
     ) {
         super(
             StoreNames.VisualizationScanResultStore,
@@ -56,7 +55,6 @@ export class VisualizationScanResultStore extends PersistentStore<VisualizationS
             idbInstance,
             IndexedDBDataKeys.visualizationScanResultStore(tabId),
             logger,
-            persistStoreData,
         );
     }
 

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -44,7 +44,6 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
         idbInstance: IndexedDBAPI,
         logger: Logger,
         tabId: number,
-        persistStoreData: boolean,
         initialVisualizationStoreDataGenerator: InitialVisualizationStoreDataGenerator,
     ) {
         super(
@@ -53,7 +52,6 @@ export class VisualizationStore extends PersistentStore<VisualizationStoreData> 
             idbInstance,
             IndexedDBDataKeys.visualizationStore(tabId),
             logger,
-            persistStoreData,
         );
 
         this.visualizationActions = visualizationActions;

--- a/src/tests/unit/common/details-view-store-data-builder.ts
+++ b/src/tests/unit/common/details-view-store-data-builder.ts
@@ -16,7 +16,6 @@ export class DetailsViewStoreDataBuilder extends BaseDataBuilder<DetailsViewStor
             null!,
             null!,
             null!,
-            null!,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/scoping-store-data-builder.ts
+++ b/src/tests/unit/common/scoping-store-data-builder.ts
@@ -7,6 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class ScopingStoreDataBuilder extends BaseDataBuilder<ScopingStoreData> {
     constructor() {
         super();
-        this.data = new ScopingStore(null!, null!, null!, null!, null!).getDefaultState();
+        this.data = new ScopingStore(null!, null!, null!, null!).getDefaultState();
     }
 }

--- a/src/tests/unit/common/tab-store-data-builder.ts
+++ b/src/tests/unit/common/tab-store-data-builder.ts
@@ -7,15 +7,6 @@ import { BaseDataBuilder } from './base-data-builder';
 export class TabStoreDataBuilder extends BaseDataBuilder<TabStoreData> {
     constructor() {
         super();
-        this.data = new TabStore(
-            null!,
-            null!,
-            null!,
-            null!,
-            null!,
-            null!,
-            null!,
-            null!,
-        ).getDefaultState();
+        this.data = new TabStore(null!, null!, null!, null!, null!, null!, null!).getDefaultState();
     }
 }

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -23,7 +23,6 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<Vis
             null,
             null,
             null,
-            null,
         ).getDefaultState();
     }
 

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -33,7 +33,6 @@ export class VisualizationStoreDataBuilder extends BaseDataBuilder<Visualization
             null,
             null,
             null,
-            true,
             new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
         ).getDefaultState();
     }

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -96,23 +96,15 @@ export class StoreMocks {
         isPageHidden: false,
         isOriginChanged: false,
     };
-    public commandStoreData = new CommandStore(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-    ).getDefaultState();
+    public commandStoreData = new CommandStore(null, null, null, null, null).getDefaultState();
     public userConfigurationStoreData = new UserConfigurationStore(
         null,
         null,
         null,
         null,
     ).getDefaultState();
-    public scopingStoreData = new ScopingStore(null, null, null, null, null).getDefaultState();
+    public scopingStoreData = new ScopingStore(null, null, null, null).getDefaultState();
     public inspectStoreData = new InspectStore(
-        null,
         null,
         null,
         null,
@@ -126,7 +118,6 @@ export class StoreMocks {
         null,
         null,
         null,
-        null,
     ).getDefaultState();
     public unifiedScanResultStoreData = new UnifiedScanResultStore(
         null,
@@ -135,10 +126,8 @@ export class StoreMocks {
         null,
         null,
         null,
-        null,
     ).getDefaultState();
     public needsReviewScanResultStoreData = new NeedsReviewScanResultStore(
-        null,
         null,
         null,
         null,
@@ -155,7 +144,6 @@ export class StoreMocks {
     public assessmentStoreData: AssessmentStoreData;
     public quickAssessStoreData: AssessmentStoreData;
     public permissionsStateStoreData = new PermissionsStateStore(
-        null,
         null,
         null,
         null,
@@ -218,7 +206,6 @@ export class StoreMocks {
             null,
             null,
             null,
-            null,
         ).getDefaultState();
         this.quickAssessCardSelectionStoreData = new AssessmentCardSelectionStore(
             null,
@@ -227,7 +214,6 @@ export class StoreMocks {
             null,
             null,
             this.initialQuickAssessStoreDataGeneratorMock.object,
-            null,
             null,
             null,
             null,

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -73,7 +73,7 @@ describe('InspectStoreTest', () => {
     ): StoreTester<InspectStoreData, InspectActions> {
         const tabActions = new TabActions();
         const factory = (actions: InspectActions) =>
-            new InspectStore(actions, tabActions, null, null, null, null, true);
+            new InspectStore(actions, tabActions, null, null, null, null);
 
         return new StoreTester(InspectActions, actionName, factory);
     }
@@ -82,7 +82,7 @@ describe('InspectStoreTest', () => {
         actionName: keyof TabActions,
     ): StoreTester<InspectStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new InspectStore(new InspectActions(), actions, null, null, null, null, true);
+            new InspectStore(new InspectActions(), actions, null, null, null, null);
         return new StoreTester(TabActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/assessment-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-card-selection-store.test.ts
@@ -60,7 +60,6 @@ describe('AssessmentCardSelectionStore', () => {
             null,
             null,
             null,
-            null,
             StoreNames.AssessmentCardSelectionStore,
         );
 
@@ -137,7 +136,6 @@ describe('AssessmentCardSelectionStore Test', () => {
                 initialAssessmentStoreDataGeneratorMock.object,
                 null,
                 null,
-                true,
                 '',
                 null,
             );
@@ -158,7 +156,6 @@ describe('AssessmentCardSelectionStore Test', () => {
                 initialAssessmentStoreDataGeneratorMock.object,
                 null,
                 null,
-                true,
                 '',
                 null,
             );
@@ -762,7 +759,6 @@ describe('AssessmentCardSelectionStore Test', () => {
                 initialAssessmentStoreDataGeneratorMock.object,
                 null,
                 null,
-                true,
                 '',
                 null,
             );
@@ -784,7 +780,6 @@ describe('AssessmentCardSelectionStore Test', () => {
                 initialAssessmentStoreDataGeneratorMock.object,
                 null,
                 null,
-                true,
                 '',
                 null,
             );

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -137,7 +137,6 @@ describe('CardSelectionStore Test', () => {
                 null,
                 null,
                 null,
-                true,
                 convertResultsToCardSelectionStoreDataCallbackMock.object,
                 convertStoreDataForScanNodeResultsCallbackMock.object,
             );
@@ -474,7 +473,6 @@ describe('CardSelectionStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(CardSelectionActions, actionName, factory);
@@ -492,7 +490,6 @@ describe('CardSelectionStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -11,7 +11,7 @@ import { StoreTester } from '../../../common/store-tester';
 
 describe('DetailsViewStoreTest', () => {
     test('getId', () => {
-        const testObject = new DetailsViewStore(null, null, null, null, null, null, null, true);
+        const testObject = new DetailsViewStore(null, null, null, null, null, null, null);
         expect(testObject.getId()).toBe(StoreNames[StoreNames.DetailsViewStore]);
     });
 
@@ -141,7 +141,6 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(ContentActions, actionName, factory);
@@ -159,7 +158,6 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(DetailsViewActions, actionName, factory);
@@ -177,7 +175,6 @@ describe('DetailsViewStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(SidePanelActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -79,14 +79,14 @@ describe('DevToolsStoreTest', () => {
     });
 
     function getDefaultState(): DevToolStoreData {
-        return new DevToolStore(null, null, null, null, null, null).getDefaultState();
+        return new DevToolStore(null, null, null, null, null).getDefaultState();
     }
 
     function createStoreTesterForDevToolsActions(
         actionName: keyof DevToolActions,
     ): StoreTester<DevToolStoreData, DevToolActions> {
         const factory = (actions: DevToolActions) =>
-            new DevToolStore(actions, null, null, null, null, true);
+            new DevToolStore(actions, null, null, null, null);
 
         return new StoreTester(DevToolActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/command-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/command-store.test.ts
@@ -31,7 +31,7 @@ describe('CommandStoreTest', () => {
     });
 
     test('on getCommands: no command modification', async () => {
-        const prototype = new CommandStore(null, null, null, null, null, null);
+        const prototype = new CommandStore(null, null, null, null, null);
         const initialState: CommandStoreData = prototype.getDefaultState();
         const expectedState: CommandStoreData = prototype.getDefaultState();
 
@@ -96,7 +96,6 @@ describe('CommandStoreTest', () => {
             null,
             null,
             null,
-            null,
         ).getDefaultState();
 
         const command: chrome.commands.Command = {
@@ -130,7 +129,7 @@ describe('CommandStoreTest', () => {
         actionName: keyof CommandActions,
     ): StoreTester<CommandStoreData, CommandActions> {
         const factory = (actions: CommandActions) =>
-            new CommandStore(actions, telemetryEventHandlerMock.object, null, null, null, true);
+            new CommandStore(actions, telemetryEventHandlerMock.object, null, null, null);
 
         return new StoreTester(CommandActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -26,7 +26,6 @@ describe('PermissionsStateStoreTest', () => {
             null,
             null,
             null,
-            true,
         );
         testSubject.initialize();
 
@@ -80,12 +79,12 @@ describe('PermissionsStateStoreTest', () => {
         actionName: keyof PermissionsStateActions,
     ): StoreTester<PermissionsStateStoreData, PermissionsStateActions> {
         const factory = (actions: PermissionsStateActions) =>
-            new PermissionsStateStore(actions, null, null, null, true);
+            new PermissionsStateStore(actions, null, null, null);
 
         return new StoreTester(PermissionsStateActions, actionName, factory);
     }
 
     function createPermissionsState(): PermissionsStateStoreData {
-        return new PermissionsStateStore(null, null, null, null, null).getDefaultState();
+        return new PermissionsStateStore(null, null, null, null).getDefaultState();
     }
 });

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -100,8 +100,7 @@ describe('ScopingStoreTest', () => {
     function createStoreForScopingActions(
         actionName: keyof ScopingActions,
     ): StoreTester<ScopingStoreData, ScopingActions> {
-        const factory = (actions: ScopingActions) =>
-            new ScopingStore(actions, null, null, null, true);
+        const factory = (actions: ScopingActions) => new ScopingStore(actions, null, null, null);
 
         return new StoreTester(ScopingActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-card-selection-store.test.ts
@@ -135,7 +135,6 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 null,
                 null,
                 null,
-                true,
                 convertResultsToCardSelectionStoreDataCallbackMock.object,
                 convertStoreDataForScanNodeResultsCallbackMock.object,
             );
@@ -503,7 +502,6 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(NeedsReviewCardSelectionActions, actionName, factory);
@@ -521,7 +519,6 @@ describe('NeedsReviewCardSelectionStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/needs-review-scan-result-store.test.ts
@@ -129,7 +129,7 @@ describe('NeedsReviewScanResultStore Test', () => {
         actionName: keyof NeedsReviewScanResultActions,
     ): StoreTester<NeedsReviewScanResultStoreData, NeedsReviewScanResultActions> {
         const factory = (actions: NeedsReviewScanResultActions) =>
-            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null, null, true);
+            new NeedsReviewScanResultStore(actions, new TabActions(), null, null, null, null);
 
         return new StoreTester(NeedsReviewScanResultActions, actionName, factory);
     }
@@ -145,7 +145,6 @@ describe('NeedsReviewScanResultStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -72,7 +72,7 @@ describe('PathSnippetStoreTest', () => {
         actionName: keyof PathSnippetActions,
     ): StoreTester<PathSnippetStoreData, PathSnippetActions> {
         const factory = (actions: PathSnippetActions) =>
-            new PathSnippetStore(actions, null, null, null, null, true);
+            new PathSnippetStore(actions, null, null, null, null);
         return new StoreTester(PathSnippetActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -132,82 +132,12 @@ describe('PersistentStoreTest', () => {
             idbInstanceMock.verifyAll();
         });
     });
-
-    describe('Do not persist store data', () => {
-        beforeEach(() => {
-            idbInstanceMock.reset();
-
-            idbInstanceMock
-                .setup(db => db.setItem(It.isAny(), It.isAny()))
-                .verifiable(Times.never());
-            idbInstanceMock.setup(db => db.removeItem(It.isAny())).verifiable(Times.never());
-        });
-
-        test('Initialize with initial state', async () => {
-            const testObject = new TestStore(true, false);
-
-            const init = { value: 'value' };
-            testObject.initialize(init);
-
-            expect(testObject.getState()).toBe(init);
-        });
-
-        test('Initialize without initial state', async () => {
-            const testObject = new TestStore(true, false);
-
-            testObject.initialize();
-
-            expect(testObject.getState()).toBe(defaultState);
-        });
-
-        test('getDefaultState', () => {
-            const testObject = new TestStore(true, false);
-
-            expect(testObject.getDefaultState()).toEqual(defaultState);
-        });
-
-        test('persistData', async () => {
-            const testObject = new TestStore(true, false);
-            const newData = { value: 'newData' };
-
-            await testObject.callPersistData(newData);
-
-            idbInstanceMock.verifyAll();
-        });
-
-        test('emitChanged', async () => {
-            const testObject = new TestStore(true, false);
-            testObject.initialize();
-
-            await testObject.callEmitChanged();
-
-            idbInstanceMock.verifyAll();
-        });
-
-        test('emitChanged with null parameters', async () => {
-            const testObject = new TestStore(false, false);
-            testObject.initialize();
-
-            await testObject.callEmitChanged();
-
-            idbInstanceMock.verifyAll();
-        });
-
-        test('Teardown', async () => {
-            const testObject = new TestStore(true, false);
-
-            await testObject.teardown();
-
-            idbInstanceMock.verifyAll();
-        });
-    });
-
     interface TestData {
         value: string;
     }
 
     class TestStore extends PersistentStore<TestData> {
-        constructor(passNonNullParams = true, persistStoreData = true) {
+        constructor(passNonNullParams = true) {
             if (passNonNullParams) {
                 super(
                     storeName,
@@ -215,10 +145,9 @@ describe('PersistentStoreTest', () => {
                     idbInstanceMock.object,
                     indexedDBDataKey,
                     loggerMock.object,
-                    persistStoreData,
                 );
             } else {
-                super(null, null, null, null, null, persistStoreData);
+                super(null, null, null, null, null);
             }
         }
 

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -251,7 +251,6 @@ describe('TabStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
                 mockUrlParser.object,
             );
         return new StoreTester(TabActions, actionName, factory);
@@ -261,16 +260,7 @@ describe('TabStoreTest', () => {
         actionName: keyof VisualizationActions,
     ): StoreTester<TabStoreData, VisualizationActions> {
         const factory = (actions: VisualizationActions) =>
-            new TabStore(
-                new TabActions(),
-                actions,
-                null,
-                null,
-                null,
-                null,
-                true,
-                mockUrlParser.object,
-            );
+            new TabStore(new TabActions(), actions, null, null, null, null, mockUrlParser.object);
         return new StoreTester(VisualizationActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -136,7 +136,6 @@ describe('UnifiedScanResultStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
@@ -153,7 +152,6 @@ describe('UnifiedScanResultStore Test', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -677,7 +677,6 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(VisualizationScanResultActions, actionName, factory);
@@ -698,7 +697,6 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(TabActions, actionName, factory);
@@ -719,7 +717,6 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(TabStopRequirementActions, actionName, factory);
@@ -740,7 +737,6 @@ describe('VisualizationScanResultStoreTest', () => {
                 null,
                 null,
                 null,
-                true,
             );
 
         return new StoreTester(VisualizationActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -67,7 +67,6 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
-                true,
                 initialVisualizationStoreDataGeneratorMock.object,
             );
 
@@ -110,7 +109,6 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
-                true,
                 initialVisualizationStoreDataGeneratorMock.object,
             );
 
@@ -151,7 +149,6 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
-                true,
                 initialVisualizationStoreDataGeneratorMock.object,
             );
 
@@ -1001,7 +998,6 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
-                true,
                 new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
             );
 
@@ -1025,7 +1021,6 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
-                true,
                 new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
             );
 
@@ -1049,7 +1044,6 @@ describe('VisualizationStoreTest ', () => {
                 null,
                 null,
                 null,
-                true,
                 new InitialVisualizationStoreDataGenerator(visualizationConfigurationFactory),
             );
 


### PR DESCRIPTION
#### Details
When we originally introduced `PersistentStore` during the MV2->MV3 transition, it included a `persistStoreData` constructor flag which allowed us to gradually transition different stores to using persistence depending on whether we were working with an MV2 or MV3 build. This functionality is now obsolete - all `PersistentStore`-based stores always use this with a constant `true` input. This PR removes the obsolete flag.

##### Motivation
Clean up obsolete code

##### Context
This is a takeover of abandoned #6300, which was closed due to the flag's usage in Unified. Now that Unified is gone, this change is unblocked.

This diff is quite large – many files are modified, but each modification is relatively small. Happy to split in any way desired to ease review.

Noticed while working on #6233

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
