### PR TITLE
fix: Exclude .ps1 files from yarn format:check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,7 @@
 **/*.nsh
 **/*.plist
 **/*.png
+**/*.ps1
 **/*.sh
 **/*.snap
 **/*.snap.html
@@ -42,6 +43,5 @@ test-results/
 yarn.lock
 src/DetailsView/components/generated-validate-assessment-json.js
 replace-plugin.js
-tools/get-chrome-web-store-refresh-token.ps1
 
 .ignoredRevs

--- a/tools/clearly-defined/check-clearly-defined.ps1
+++ b/tools/clearly-defined/check-clearly-defined.ps1
@@ -7,7 +7,7 @@ Determine if this is a dependabot PR. If it is and the package being updated is 
 if ClearlyDefined has information for the current version. Fail the build is it's not there.
 
 .DESCRIPTION
-ClearlyDefined is our source of license information for dependemncies, but it often lags behind
+ClearlyDefined is our source of license information for dependencies, but it often lags behind
 the latest version of a package. This script exists to detect this scenario and to serve as a
 reminder to request that ClearlyDefined harvest information for the version being updated. It
 also provides a way to exclude packages that we know will never be in ClearlyDefined.


### PR DESCRIPTION
#### Details
When running `yarn fastpass`, the following error is printed to the console:

```
[format:check   ] [error] No parser could be inferred for file "C:\Users\billdengler\k4w\tools\clearly-defined\check-clearly-defined.ps1".
```

This PR excludes all `.ps1` files from format checking.

It also fixes a small typo in the clearly defined script.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
