### PR TITLE
fix: Correct bug in ClearlyDefined check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -43,5 +43,6 @@ test-results/
 yarn.lock
 src/DetailsView/components/generated-validate-assessment-json.js
 replace-plugin.js
+**/*.bat
 
 .ignoredRevs

--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -46,6 +46,11 @@
                 "prepend": "# "
             }
         },
+        "bat": {
+            "eachLine": {
+                "prepend": ":: "
+            }
+        },
         "md": {
             "prepend": "<!--",
             "append": "-->"

--- a/tools/clearly-defined/ValidateScript.bat
+++ b/tools/clearly-defined/ValidateScript.bat
@@ -1,0 +1,71 @@
+:: Copyright (c) Microsoft Corporation. All rights reserved.
+:: Licensed under the MIT License.
+
+@echo off
+:: Validator for check-clearly-defined.ps1
+::
+:: Executes check-clearly-defined.ps1 in various scenarios to check script correctness
+
+setlocal
+cls
+
+@echo Skipped case: Non-dependabot branch
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName fix-bug
+pwsh -f ./check-clearly-defined.ps1 -PipelineType ado -BranchName fix-bug
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+echo Passing case: ADO PR build of dependabot branch
+echo set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
+set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: ADO non-PR build of dependabot branch
+set SYSTEM_PULLREQUEST_SOURCEBRANCH=
+set BUILD_SOURCEBRANCH=refs/heads/dependabot/nuget/src/Axe.Windows-2.1.3
+echo set BUILD_SOURCEBRANCH=refs/heads/dependabot/nuget/src/Axe.Windows-2.1.3
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: action PR build of dependabot branch without namespace
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=dependabot/npm_and_yarn/eslint-config-prettier-8.9.0
+echo set GITHUB_HEAD_REF=dependabot/npm_and_yarn/eslint-config-prettier-8.9.0
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Passing case: action PR build of dependabot branch with namespace
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-6.3.0
+echo set GITHUB_HEAD_REF=dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-6.3.0
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+pwsh -f ./check-clearly-defined.ps1 -PipelineType action
+if errorlevel 1 goto fail
+echo OK
+echo.
+
+@echo Failing case: Package that does not exist in ClearlyDefined
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
+pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
+if errorlevel 2 goto succeeded
+goto fail
+
+:succeeded
+echo OK
+echo.
+echo ALL TESTS ARE OK :)
+goto :eof
+
+:fail
+echo TEST FAILED -- PLEASE DEBUG THE SCRIPT!


### PR DESCRIPTION
#### Details

Note: This change is a port of https://github.com/microsoft/accessibility-insights-windows/pull/1672

#954 had 2 bugs about namespaces:
1. Dependabot adds a `/src` component to the branch name of NuGet component. The script didn't take this into account and we ended up with an incorrect url
2. Dependabot omits the `@` from branch names of npm components that include a namespace. The script didn't take this into accoiunt and we ended up with an incorrect url

The fix in both cases is the same--we add a function to adjust the raw namespace that comes from parsing the branch name. 

It also includes a batch script to aid in script validation. If we encounter future branch names that go awry, we can just add additional test cases and have protection against breakage.

##### Motivation

Tune the desired friction of dependabot PR's, keep the generated notices file current

##### Output

Here is the output of the script:
```
C:>ValidateScript.bat
Skipped case: Non-dependabot branch
pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName fix-bug
Not a dependabot PR, skipping check
OK

Passing case: ADO PR build of dependabot branch
set SYSTEM_PULLREQUEST_SOURCEBRANCH=dependabot/nuget/src/Moq-4.18.4
pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
Getting data from https://api.clearlydefined.io/definitions/nuget/nuget/-/Moq/4.18.4
ClearlyDefined has a definition for this package version.
OK

Passing case: ADO non-PR build of dependabot branch
set BUILD_SOURCEBRANCH=refs/heads/dependabot/nuget/src/Axe.Windows-2.1.3
pwsh -f ./check-clearly-defined.ps1 -PipelineType ado
Getting data from https://api.clearlydefined.io/definitions/nuget/nuget/-/Axe.Windows/2.1.3
ClearlyDefined has a definition for this package version.
OK

Passing case: action PR build of dependabot branch without namespace
set GITHUB_HEAD_REF=dependabot/npm_and_yarn/eslint-config-prettier-8.9.0
pwsh -f ./check-clearly-defined.ps1 -PipelineType action
Getting data from https://api.clearlydefined.io/definitions/npm/npmjs/-/eslint-config-prettier/8.9.0
ClearlyDefined has a definition for this package version.
OK

Passing case: action PR build of dependabot branch with namespace
set GITHUB_HEAD_REF=dependabot/npm_and_yarn/typescript-eslint/eslint-plugin-6.3.0
pwsh -f ./check-clearly-defined.ps1 -PipelineType action
Getting data from https://api.clearlydefined.io/definitions/npm/npmjs/@typescript-eslint/eslint-plugin/6.3.0
ClearlyDefined has a definition for this package version.
OK

Failing case: Package that does not exist in ClearlyDefined
pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
Getting data from https://api.clearlydefined.io/definitions/nuget/nuget/-/Axe.Windows/2.99.99
ClearlyDefined does not have a definition for this package version.
If this is a development component, you may safely ignore this warning.

If this is a production component, please do the following:
1. Request that ClearlyDefined harvest information for this package version
2. Wait for the harvest to complete -- check https://clearlydefined.io
3. Re-run the failed build
4. Once the PR build passes, merge the PR
5. If necessary, add this package to clearly-defined-exclusions.json and include it in your PR.
   Merge the PR once the build passes.
OK

ALL TESTS ARE OK :)
```
##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
The validation script could have been another PowerShell script if we were concerned about allowing validation cross-platform, but this seems like a sufficient option

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
