### PR TITLE
chore: Make task name more useful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,12 +243,12 @@ jobs:
         path: packages/report-e2e-tests/test-results
       timeout-minutes: 3
 
-  check-dependencies:
+  check-clearly-defined:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3.5.3
       timeout-minutes: 2
 
-    - name: Run script
+    - name: Check ClearlyDefined for dependabot PR's
       run: ./tools/clearly-defined/check-clearly-defined.ps1 -Verbose -PipelineType action
       shell: pwsh


### PR DESCRIPTION
#### Details

#6859 added the check to ClearlyDefined for dependabot PR's, but it used a very vague name for the step that actually calls ClearlyDefined. 

This renames the workflow step from `check-dependencies` to `check-clearly-defined`. It also renames the core task from `Run script` to `Check ClearlyDefined for dependabot PR's`

##### Motivation

Make it clearer what this step is in the logs

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
