### PR TITLE
fix: Merge persisted state into default state by default

### DIFF
--- a/src/common/flux/persistent-store.ts
+++ b/src/common/flux/persistent-store.ts
@@ -4,7 +4,7 @@ import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Logger } from 'common/logging/logger';
 import { StoreNames } from 'common/stores/store-names';
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep, isEmpty, isEqual, merge } from 'lodash';
 
 export abstract class PersistentStore<TState> extends BaseStoreImpl<TState, Promise<void>> {
     private previouslyPersistedState: TState | null;
@@ -30,13 +30,14 @@ export abstract class PersistentStore<TState> extends BaseStoreImpl<TState, Prom
 
     // Allow specific stores to override default state behavior
     protected generateDefaultState(persistedData: TState): TState {
-        return persistedData;
+        const defaultState = this.getDefaultState();
+        return !isEmpty(persistedData) ? merge({}, defaultState, persistedData) : defaultState;
     }
 
     public override initialize(initialState?: TState): void {
         const generatedPersistedState = this.generateDefaultState(this.persistedState);
 
-        this.state = initialState || (generatedPersistedState ?? this.getDefaultState());
+        this.state = initialState || generatedPersistedState;
 
         this.addActionListeners();
     }

--- a/src/tests/unit/tests/background/stores/assessment-card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-card-selection-store.test.ts
@@ -749,6 +749,9 @@ describe('AssessmentCardSelectionStore Test', () => {
     function createStoreForAssessmentCardSelectionActions(
         actionName: keyof AssessmentCardSelectionActions,
     ): StoreTester<AssessmentCardSelectionStoreData, AssessmentCardSelectionActions> {
+        const assessmentStoreState: AssessmentStoreData = createAssessmentStoreDataWithStatus(
+            ManualTestStatus.UNKNOWN,
+        );
         const factory = (actions: AssessmentCardSelectionActions) =>
             new AssessmentCardSelectionStore(
                 actions,
@@ -763,6 +766,8 @@ describe('AssessmentCardSelectionStore Test', () => {
                 null,
             );
 
+        setupDataGeneratorMock(null, assessmentStoreState);
+
         return new StoreTester(AssessmentCardSelectionActions, actionName, factory);
     }
 
@@ -770,6 +775,10 @@ describe('AssessmentCardSelectionStore Test', () => {
         actionName: keyof AssessmentActions,
         assessmentsProvider?: AssessmentsProvider,
     ): StoreTester<AssessmentCardSelectionStoreData, AssessmentActions> {
+        const assessmentStoreState: AssessmentStoreData = createAssessmentStoreDataWithStatus(
+            ManualTestStatus.UNKNOWN,
+        );
+
         const factory = (actions: AssessmentActions) =>
             new AssessmentCardSelectionStore(
                 new AssessmentCardSelectionActions(),
@@ -783,6 +792,8 @@ describe('AssessmentCardSelectionStore Test', () => {
                 '',
                 null,
             );
+
+        setupDataGeneratorMock(null, assessmentStoreState);
 
         return new StoreTester(AssessmentActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/persistent-store.test.ts
+++ b/src/tests/unit/tests/background/stores/persistent-store.test.ts
@@ -34,7 +34,7 @@ describe('PersistentStoreTest', () => {
 
             testObject.initialize();
 
-            expect(testObject.getState()).toBe(persistedState);
+            expect(testObject.getState()).toStrictEqual(persistedState);
         });
 
         test('Initialize without persisted data', async () => {


### PR DESCRIPTION
#### Details
This PR updates `PersistantStore.generateDefaultState` to merge in `persistedState` to `defaultState`, rather than just returning `persistedState` as-is.

##### Motivation

Addresses #6233.

#### Pull request checklist
- [x] Addresses an existing issue: #6233
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
