### PR TITLE
fix: Fix typo in tab stop instructions

### DIFF
--- a/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
+++ b/src/DetailsView/components/adhoc-tab-stops-test-view.tsx
@@ -84,7 +84,7 @@ export const AdhocTabStopsTestView = NamedFC<AdhocTabStopsTestViewProps>(
                 <ol>
                     <li>
                         Use your keyboard to move input focus through all the interactive elements
-                        in the page--
+                        on the page&nbsp;&ndash;{' '}
                         <Markup.Emphasis>
                             please traverse the entire page before returning to this window
                         </Markup.Emphasis>

--- a/src/content/adhoc/tabstops/how-to-test.tsx
+++ b/src/content/adhoc/tabstops/how-to-test.tsx
@@ -16,8 +16,7 @@ export const createHowToTest = (headingLevel: number) => {
                 <li>Refresh the target page to put it in its default state.</li>
                 <li>Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.</li>
                 <li>
-                    Use your keyboard to move input focus through all the interactive elements on the page&nbsp;&ndash;{' '}
-                    <Markup.Emphasis>please traverse the entire page before returning to this window</Markup.Emphasis>
+                    Use your keyboard to move input focus through all the interactive elements in the page:
                     <ul>
                         <li>Use Tab and Shift+Tab to navigate between standalone controls.</li>
                         <li>Use the arrow keys to navigate between the focusable elements within a composite control.</li>

--- a/src/content/adhoc/tabstops/how-to-test.tsx
+++ b/src/content/adhoc/tabstops/how-to-test.tsx
@@ -16,7 +16,7 @@ export const createHowToTest = (headingLevel: number) => {
                 <li>Refresh the target page to put it in its default state.</li>
                 <li>Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.</li>
                 <li>
-                    Use your keyboard to move input focus through all the interactive elements in the page:
+                    Use your keyboard to move input focus through all the interactive elements on the page:
                     <ul>
                         <li>Use Tab and Shift+Tab to navigate between standalone controls.</li>
                         <li>Use the arrow keys to navigate between the focusable elements within a composite control.</li>

--- a/src/content/adhoc/tabstops/how-to-test.tsx
+++ b/src/content/adhoc/tabstops/how-to-test.tsx
@@ -16,7 +16,8 @@ export const createHowToTest = (headingLevel: number) => {
                 <li>Refresh the target page to put it in its default state.</li>
                 <li>Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.</li>
                 <li>
-                    Use your keyboard to move input focus through all the interactive elements in the page:
+                    Use your keyboard to move input focus through all the interactive elements on the page&nbsp;&ndash;{' '}
+                    <Markup.Emphasis>please traverse the entire page before returning to this window</Markup.Emphasis>
                     <ul>
                         <li>Use Tab and Shift+Tab to navigate between standalone controls.</li>
                         <li>Use the arrow keys to navigate between the focusable elements within a composite control.</li>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -1195,7 +1195,7 @@ exports[`Guidance Content pages adhoc/tabstops/guidance matches the snapshot 1`]
           Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.
         </li>
         <li>
-          Use your keyboard to move input focus through all the interactive elements in the page:
+          Use your keyboard to move input focus through all the interactive elements on the page:
           <ul>
             <li>
               Use Tab and Shift+Tab to navigate between standalone controls.

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -1195,7 +1195,10 @@ exports[`Guidance Content pages adhoc/tabstops/guidance matches the snapshot 1`]
           Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.
         </li>
         <li>
-          Use your keyboard to move input focus through all the interactive elements in the page:
+          Use your keyboard to move input focus through all the interactive elements on the page – 
+          <em>
+            please traverse the entire page before returning to this window
+          </em>
           <ul>
             <li>
               Use Tab and Shift+Tab to navigate between standalone controls.

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -1195,10 +1195,7 @@ exports[`Guidance Content pages adhoc/tabstops/guidance matches the snapshot 1`]
           Turn on the Show tab stops toggle. An empty circle will highlight the element with focus.
         </li>
         <li>
-          Use your keyboard to move input focus through all the interactive elements on the page – 
-          <em>
-            please traverse the entire page before returning to this window
-          </em>
+          Use your keyboard to move input focus through all the interactive elements in the page:
           <ul>
             <li>
               Use Tab and Shift+Tab to navigate between standalone controls.

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-tab-stops-test-view.test.tsx.snap
@@ -35,7 +35,8 @@ exports[`AdhocTabStopsTestView render handles guidance 1`] = `
             </p>
             <ol>
               <li>
-                Use your keyboard to move input focus through all the interactive elements in the page--
+                Use your keyboard to move input focus through all the interactive elements on the page –
+                 
                 <Emphasis>
                   please traverse the entire page before returning to this window
                 </Emphasis>
@@ -175,7 +176,8 @@ exports[`AdhocTabStopsTestView render handles no guidance 1`] = `
             </p>
             <ol>
               <li>
-                Use your keyboard to move input focus through all the interactive elements in the page--
+                Use your keyboard to move input focus through all the interactive elements on the page –
+                 
                 <Emphasis>
                   please traverse the entire page before returning to this window
                 </Emphasis>


### PR DESCRIPTION
#### Details
This PR fixes a small typo in the tab stop instructions.

##### Context
Discovered during 2.39.0 release validation.

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA
