### PR TITLE
feat(quick-assess-ux): Enable report export functionality in QuickAssess

### DIFF
--- a/src/DetailsView/components/report-export-dialog-factory.tsx
+++ b/src/DetailsView/components/report-export-dialog-factory.tsx
@@ -15,6 +15,8 @@ import { ShouldShowReportExportButtonProps } from 'DetailsView/components/should
 import * as React from 'react';
 import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
 import { ReportExportServiceKey } from 'report-export/types/report-export-service';
+import { AssessmentReportBodyHeader } from 'reports/components/assessment-report-body-header';
+import { QuickAssessReportBodyHeader } from 'reports/components/quick-assess-report-body-header';
 import { FastPassReportModel } from 'reports/fast-pass-report-html-generator';
 
 export type ReportExportDialogFactoryDeps = {
@@ -31,8 +33,10 @@ export type ReportExportDialogFactoryProps = CommandBarProps & {
     tabStopRequirementData: TabStopRequirementState;
 };
 
-export function getReportExportDialogForAssessment(
+function getReportExportDialog(
     props: ReportExportDialogFactoryProps,
+    reportExportFormat: ReportExportFormat,
+    bodyHeader: JSX.Element,
 ): JSX.Element {
     const {
         deps,
@@ -46,7 +50,7 @@ export function getReportExportDialogForAssessment(
     const { reportGenerator, getProvider } = deps;
     const dialogProps: ReportExportComponentProps = {
         deps: deps,
-        reportExportFormat: 'Assessment',
+        reportExportFormat: reportExportFormat,
         pageTitle: scanMetadata.targetAppInfo.name,
         scanDate: deps.getCurrentDate(),
         htmlGenerator: description =>
@@ -56,6 +60,8 @@ export function getReportExportDialogForAssessment(
                 featureFlagStoreData,
                 scanMetadata.targetAppInfo,
                 description,
+                `${reportExportFormat} report`,
+                bodyHeader,
             ),
         jsonGenerator: description =>
             reportGenerator.generateAssessmentJsonExport(
@@ -83,10 +89,18 @@ export function getReportExportDialogForAssessment(
     return <ReportExportComponent {...dialogProps} />;
 }
 
+export function getReportExportDialogForAssessment(
+    props: ReportExportDialogFactoryProps,
+): JSX.Element {
+    const BodyHeader = <AssessmentReportBodyHeader />;
+    return getReportExportDialog(props, 'Assessment', BodyHeader);
+}
+
 export function getReportExportDialogForQuickAssess(
     props: ReportExportDialogFactoryProps,
-): JSX.Element | null {
-    return null;
+): JSX.Element {
+    const BodyHeader = <QuickAssessReportBodyHeader />;
+    return getReportExportDialog(props, 'QuickAssess', BodyHeader);
 }
 
 export function getReportExportDialogForFastPass(

--- a/src/DetailsView/components/should-show-report-export-button.ts
+++ b/src/DetailsView/components/should-show-report-export-button.ts
@@ -18,7 +18,7 @@ export function shouldShowReportExportButtonForAssessment(): boolean {
 }
 
 export function shouldShowReportExportButtonForQuickAssess(): boolean {
-    return false;
+    return true;
 }
 
 export function shouldShowReportExportButtonForFastpass(

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -102,7 +102,7 @@ export const TRANSFER_QUICK_ASSESS_DATA_TO_ASSESSMENT_INITIATED: string =
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';
 
-export type ReportExportFormat = 'Assessment' | 'FastPass';
+export type ReportExportFormat = 'Assessment' | 'FastPass' | 'QuickAssess';
 
 export enum TelemetryEventSource {
     LaunchPad,

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -34,6 +34,8 @@ export class AssessmentReportHtmlGenerator {
         featureFlagStoreData: FeatureFlagStoreData,
         targetAppInfo: TargetAppData,
         description: string,
+        title: string,
+        bodyHeader: JSX.Element,
     ): string {
         const filteredProvider = assessmentsProviderWithFeaturesEnabled(
             assessmentsProvider,
@@ -55,13 +57,14 @@ export class AssessmentReportHtmlGenerator {
             <React.Fragment>
                 <head>
                     <meta charSet="UTF-8" />
-                    <title>Assessment report</title>
+                    <title>{title}</title>
                     <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
                     <style dangerouslySetInnerHTML={{ __html: bundledStyles.styleSheet }} />
                 </head>
                 <body>
                     <AssessmentReport
                         deps={this.deps}
+                        bodyHeader={bodyHeader}
                         data={model}
                         description={description}
                         extensionVersion={this.extensionVersion}

--- a/src/reports/components/assessment-report-body.tsx
+++ b/src/reports/components/assessment-report-body.tsx
@@ -8,7 +8,6 @@ import {
     AssessmentReportAssessmentList,
     AssessmentReportAssessmentListDeps,
 } from './assessment-report-assessment-list';
-import { AssessmentReportBodyHeader } from './assessment-report-body-header';
 import { AssessmentReportSummary } from './assessment-report-summary';
 import { AssessmentScanDetails, AssessmentScanDetailsDeps } from './assessment-scan-details';
 import { OutcomeChip } from './outcome-chip';
@@ -19,6 +18,7 @@ export type AssessmentReportBodyDeps = AssessmentReportAssessmentListDeps &
 
 export interface AssessmentReportBodyProps {
     deps: AssessmentReportBodyDeps;
+    bodyHeader: JSX.Element;
     data: ReportModel;
     description: string;
 }
@@ -27,7 +27,7 @@ export class AssessmentReportBody extends React.Component<AssessmentReportBodyPr
     public render(): JSX.Element {
         return (
             <div className="assessment-report-body" role="main">
-                <AssessmentReportBodyHeader />
+                {this.props.bodyHeader}
                 <AssessmentReportSummary summary={this.props.data.summary} />
                 <AssessmentScanDetails
                     deps={this.props.deps}

--- a/src/reports/components/assessment-report.tsx
+++ b/src/reports/components/assessment-report.tsx
@@ -11,6 +11,7 @@ export type AssessmentReportDeps = AssessmentReportBodyDeps;
 
 export interface AssessmentReportProps {
     deps: AssessmentReportDeps;
+    bodyHeader: JSX.Element;
     data: ReportModel;
     description: string;
     extensionVersion: string;
@@ -30,6 +31,7 @@ export class AssessmentReport extends React.Component<AssessmentReportProps> {
                 <HeaderSection targetAppInfo={targetAppInfo} headerText={productName} />
                 <AssessmentReportBody
                     deps={this.props.deps}
+                    bodyHeader={this.props.bodyHeader}
                     data={this.props.data}
                     description={this.props.description}
                 />

--- a/src/reports/components/quick-assess-report-body-header.scss
+++ b/src/reports/components/quick-assess-report-body-header.scss
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+@import '../../common/styles/fonts.scss';
+
+.quick-assess-report-body-header {
+    margin-bottom: 21px;
+
+    h1 {
+        font-size: 28px;
+        margin-top: 0;
+        margin-bottom: 24px;
+        font-weight: $font-weight-semi-bold;
+        line-height: 40px;
+        letter-spacing: -1;
+    }
+
+    p {
+        font-size: 14px;
+        color: $secondary-text;
+        font-family: $font-family;
+        margin: 0;
+        line-height: 20px;
+    }
+}

--- a/src/reports/components/quick-assess-report-body-header.tsx
+++ b/src/reports/components/quick-assess-report-body-header.tsx
@@ -8,7 +8,8 @@ export class QuickAssessReportBodyHeader extends React.Component {
             <div className="quick-assess-report-body-header">
                 <h1>QuickAssess report</h1>
                 <p>
-                    This report shows the results from a combination of assisted and manual tests that cover limited aspects of the WCAG 2.1 AA success criteria.
+                    This report shows the results from a combination of assisted and manual tests
+                    that cover limited aspects of the WCAG 2.1 AA success criteria.
                 </p>
             </div>
         );

--- a/src/reports/components/quick-assess-report-body-header.tsx
+++ b/src/reports/components/quick-assess-report-body-header.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+export class QuickAssessReportBodyHeader extends React.Component {
+    public render(): JSX.Element {
+        return (
+            <div className="quick-assess-report-body-header">
+                <h1>QuickAssess report</h1>
+                <p>
+                    This report shows the results from a combination of assisted and manual tests that cover limited aspects of the WCAG 2.1 AA success criteria.
+                </p>
+            </div>
+        );
+    }
+}

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -28,6 +28,8 @@ export class ReportGenerator {
         featureFlagStoreData: FeatureFlagStoreData,
         targetAppInfo: TargetAppData,
         description: string,
+        title: string,
+        bodyHeader: JSX.Element,
     ): string {
         return this.assessmentReportHtmlGenerator.generateHtml(
             assessmentStoreData,
@@ -35,6 +37,8 @@ export class ReportGenerator {
             featureFlagStoreData,
             targetAppInfo,
             description,
+            title,
+            bodyHeader,
         );
     }
 

--- a/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-dialog-factory.test.tsx
@@ -24,7 +24,9 @@ import {
     ShouldShowReportExportButton,
     ShouldShowReportExportButtonProps,
 } from 'DetailsView/components/should-show-report-export-button';
+import * as React from 'react';
 import { ReportExportServiceProvider } from 'report-export/report-export-service-provider';
+import { AssessmentReportBodyHeader } from 'reports/components/assessment-report-body-header';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -131,6 +133,9 @@ describe('ReportExportDialogFactory', () => {
     }
 
     function setAssessmentReportGenerator(): void {
+        const TITLE = 'Assessment report';
+        const bodyHeader = <AssessmentReportBodyHeader />;
+
         reportGeneratorMock
             .setup(reportGenerator =>
                 reportGenerator.generateAssessmentHtmlReport(
@@ -139,6 +144,8 @@ describe('ReportExportDialogFactory', () => {
                     featureFlagStoreData,
                     targetAppInfo,
                     theDescription,
+                    TITLE,
+                    bodyHeader,
                 ),
             )
             .returns(() => theGeneratorOutput)

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -14,6 +14,7 @@ import { AssessmentReportModelBuilder } from 'reports/assessment-report-model-bu
 import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-model-builder-factory';
 import * as reportStyles from 'reports/assessment-report.styles';
 import { AssessmentReport } from 'reports/components/assessment-report';
+import { AssessmentReportBodyHeader } from 'reports/components/assessment-report-body-header';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { It, Mock, MockBehavior } from 'typemoq';
 
@@ -42,13 +43,15 @@ describe('AssessmentReportHtmlGenerator', () => {
 
         const modelBuilderMock = Mock.ofType(AssessmentReportModelBuilder, MockBehavior.Strict);
         const model: ReportModel = { stub: 'model' } as any;
+        const TITLE = 'Assessment report';
+        const bodyHeader = <AssessmentReportBodyHeader />;
 
         // tslint:disable: react-no-dangerous-html
         const expectedComponent = (
             <React.Fragment>
                 <head>
                     <meta charSet="UTF-8" />
-                    <title>Assessment report</title>
+                    <title>{TITLE}</title>
                     <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
                     <style dangerouslySetInnerHTML={{ __html: detailsViewBundledCSS.styleSheet }} />
                 </head>
@@ -56,6 +59,7 @@ describe('AssessmentReportHtmlGenerator', () => {
                     <AssessmentReport
                         deps={deps}
                         data={model}
+                        bodyHeader={bodyHeader}
                         description={description}
                         extensionVersion="ProductVersion"
                         axeVersion="axeVersion"
@@ -108,6 +112,8 @@ describe('AssessmentReportHtmlGenerator', () => {
             featureFlagStoreData,
             targetAppInfo,
             description,
+            TITLE,
+            bodyHeader,
         );
 
         expect(actualHtml).toEqual(expectedHtml);

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-report.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-report.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`AssessmentReport render 1`] = `
     }
   />
   <AssessmentReportBody
+    bodyHeader={<AssessmentReportBodyHeader />}
     data={
       {
         "failedDetailsData": [

--- a/src/tests/unit/tests/reports/components/assessment-report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report-body.test.tsx
@@ -7,6 +7,7 @@ import {
     AssessmentReportBodyDeps,
     AssessmentReportBodyProps,
 } from 'reports/components/assessment-report-body';
+import { AssessmentReportBodyHeader } from 'reports/components/assessment-report-body-header';
 import { AssessmentReportBuilderTestHelper } from '../../DetailsView/assessment-report-builder-test-helper';
 
 describe('AssessmentReportBody', () => {
@@ -17,10 +18,13 @@ describe('AssessmentReportBody', () => {
             } as any,
         } as AssessmentReportBodyDeps;
 
+        const bodyHeader = <AssessmentReportBodyHeader />;
+
         const props: AssessmentReportBodyProps = {
             deps: deps,
             data: AssessmentReportBuilderTestHelper.getAssessmentReportModel(),
             description: 'test-description',
+            bodyHeader: bodyHeader,
         };
 
         const wrapper = shallow(<AssessmentReportBody {...props} />);

--- a/src/tests/unit/tests/reports/components/assessment-report.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { AssessmentReport, AssessmentReportDeps } from 'reports/components/assessment-report';
+import { AssessmentReportBodyHeader } from 'reports/components/assessment-report-body-header';
 import { AssessmentReportBuilderTestHelper } from '../../DetailsView/assessment-report-builder-test-helper';
 
 describe('AssessmentReport', () => {
@@ -16,10 +17,13 @@ describe('AssessmentReport', () => {
 
         const data = AssessmentReportBuilderTestHelper.getAssessmentReportModel();
 
+        const bodyHeader = <AssessmentReportBodyHeader />;
+
         const wrapper = shallow(
             <AssessmentReport
                 deps={deps}
                 data={data}
+                bodyHeader={bodyHeader}
                 description="test string"
                 extensionVersion="ProductVersion"
                 axeVersion="axeVersion"

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -4,8 +4,10 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStopRequirementState } from 'common/types/store-data/visualization-scan-result-data';
+import * as React from 'react';
 import { AssessmentJsonExportGenerator } from 'reports/assessment-json-export-generator';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
+import { AssessmentReportBodyHeader } from 'reports/components/assessment-report-body-header';
 import {
     FastPassReportHtmlGenerator,
     FastPassReportModel,
@@ -82,6 +84,8 @@ describe('ReportGenerator', () => {
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const assessmentsProvider: AssessmentsProvider = { stub: 'assessmentsProvider' } as any;
         const assessmentDescription = 'generateAssessmentHtml-description';
+        const TITLE = 'Assessment report';
+        const bodyHeader = React.createElement(AssessmentReportBodyHeader, {}, null);
 
         assessmentReportHtmlGeneratorMock
             .setup(builder =>
@@ -91,6 +95,8 @@ describe('ReportGenerator', () => {
                     featureFlagStoreDataStub,
                     targetPage,
                     assessmentDescription,
+                    TITLE,
+                    bodyHeader,
                 ),
             )
             .returns(() => 'generated-assessment-html')
@@ -102,6 +108,8 @@ describe('ReportGenerator', () => {
             featureFlagStoreDataStub,
             targetPage,
             assessmentDescription,
+            TITLE,
+            bodyHeader,
         );
 
         const expected = 'generated-assessment-html';


### PR DESCRIPTION
#### Details
This PR enables the "export results" option in a QuickAssess assessment. I've confirmed that an HTML report generates showing a scoped-down list of assessments and expected passing and failing states.

##### Motivation
Part of [Feature 2012896](https://mseng.visualstudio.com/1ES/_queries/edit/2012896) (internal access required to view).

#### Pull request checklist
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [?] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA
