### PR TITLE
feat(quick-assess-ux): Adjust styling of RequirementContextView to better align with rest of extension

### DIFF
--- a/src/DetailsView/components/help-links.scss
+++ b/src/DetailsView/components/help-links.scss
@@ -8,6 +8,6 @@
     padding-bottom: 5px;
     font-family: $font-family;
     line-height: 20px;
-    font-size: 15px;
+    font-size: 14px;
     color: $communication-primary;
 }

--- a/src/DetailsView/components/requirement-context-section.scss
+++ b/src/DetailsView/components/requirement-context-section.scss
@@ -11,6 +11,10 @@
     background-color: $help-links-section-background;
     border: 1px solid $help-links-section-border;
     box-sizing: border-box;
+
+    p {
+        margin-block-end: 2em;
+    }
 }
 
 .context-heading {
@@ -23,15 +27,21 @@
 }
 
 .context-links > * {
-    padding-left: 0;
-    padding-top: 5px;
-    padding-bottom: 5px;
     font-family: $font-family;
-    line-height: 20px;
-    font-size: 15px;
+    font-size: 14px;
+
+    &:global(.ms-Button) {
+        padding: 0;
+        margin: 0;
+        height: max-content;
+        padding-bottom: 5px;
+        border: none;
+    }
 
     :global(.ms-Button-label) {
-        margin-left: 0 !important;
+        margin-left: 0;
+        margin-right: 0;
+        line-height: 20px;
         color: $link;
 
         &:hover {


### PR DESCRIPTION
#### Details

 `RequirementContextView` has two sections:
* Why it matters
  *  heading
  * paragraph of text
* Help
  *  heading
  * a button styled to look like a link (Info and Examples)
  * 0+ help links

Currently, there is inconsistent spacing between the info and examples button and help links, more spacing between the "Help" heading and Info and Examples button than between the "Why it matters" paragraph and the "Help" heading (between the two sections), and the font size of the help links (15px) is inconsistent with the rest of the extension's text (14px). 

This PR makes the spacing between the button and links consistent, adds additional spacing between the "Why it matters" paragraph and "Help" heading to better distinguish the two sections, and changes the help links font size to match the rest of the application. 

Before:

![screenshot of requirement context view with odd spacing and two different font sizes](https://github.com/microsoft/accessibility-insights-web/assets/3230904/ec727366-e049-41df-bea3-27638de8e478)

After:

![screenshot of requirement context view with even spacing and the same font size for text and links](https://github.com/microsoft/accessibility-insights-web/assets/3230904/a99cd3c2-68de-471e-9d62-7d5d6fc5626f)


##### Motivation

addresses issue #6555 

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6555
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
