### PR TITLE
feat(quick-assess-ux): Force Automated Checks nav link to render as a link for Quick Assess

### DIFF
--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -112,6 +112,7 @@ export class LeftNavLinkBuilder {
         expandedTest: VisualizationType | undefined,
         onRightPanelContentSwitch: () => void,
         featureFlagStoreData: FeatureFlagStoreData,
+        forceAnchor: boolean = false,
     ): BaseLeftNavLink {
         const assessment = assessmentsProvider.forKey('automated-checks')!;
 
@@ -122,6 +123,7 @@ export class LeftNavLinkBuilder {
                   assessment,
                   startingIndex,
                   assessmentsData,
+                  forceAnchor,
               )
             : this.buildCollapsibleAssessmentLink(
                   deps,
@@ -130,6 +132,7 @@ export class LeftNavLinkBuilder {
                   assessmentsData,
                   isExpanded,
                   onRightPanelContentSwitch,
+                  forceAnchor,
               );
 
         return test;
@@ -180,6 +183,7 @@ export class LeftNavLinkBuilder {
         expandedTest: VisualizationType | undefined,
         onRightPanelContentSwitch: () => void,
         featureFlagStoreData: FeatureFlagStoreData,
+        forceAnchor: boolean = false,
     ): BaseLeftNavLink[] {
         const assessments = assessmentsProvider.all();
         let index = startingIndex;
@@ -197,6 +201,7 @@ export class LeftNavLinkBuilder {
                 assessmentsData,
                 isExpanded,
                 onRightPanelContentSwitch,
+                forceAnchor,
             );
             index++;
             return test;
@@ -210,6 +215,7 @@ export class LeftNavLinkBuilder {
         assessment: Assessment,
         index: number,
         assessmentsData: DictionaryStringTo<ManualTestStatusData>,
+        forceAnchor: boolean = false,
     ): AssessmentLeftNavLink => {
         const {
             getStatusForTest,
@@ -239,7 +245,7 @@ export class LeftNavLinkBuilder {
             status,
             title: `${index}: ${name} (${narratorTestStatus})`,
             testType: assessment.visualizationType,
-            forceAnchor: false,
+            forceAnchor,
         };
 
         return testLink;
@@ -252,6 +258,7 @@ export class LeftNavLinkBuilder {
         assessmentsData: DictionaryStringTo<ManualTestStatusData>,
         isExpanded: boolean,
         onRightPanelContentSwitch: () => void,
+        forceAnchor: boolean = false,
     ): AssessmentLeftNavLink => {
         const {
             getStatusForTest,
@@ -308,7 +315,7 @@ export class LeftNavLinkBuilder {
             links: [gettingStartedLink, ...requirementLinks],
             isExpanded: isExpanded,
             testType: assessment.visualizationType,
-            forceAnchor: false,
+            forceAnchor,
         };
 
         return testLink;

--- a/src/DetailsView/components/left-nav/quick-assess-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/quick-assess-left-nav.tsx
@@ -71,6 +71,7 @@ export const QuickAssessLeftNav = NamedFC<QuickAssessLeftNavProps>('QuickAssessL
             expandedTest,
             onRightPanelContentSwitch,
             featureFlagStoreData,
+            true,
         ),
     );
 

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessme
 }
 `;
 
-exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link with feature flag false 1`] = `
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as button with feature flag false 1`] = `
 {
   "forceAnchor": false,
   "iconProps": {
@@ -595,7 +595,7 @@ exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated ch
 }
 `;
 
-exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link with feature flag false 2`] = `
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as button with feature flag false 2`] = `
 {
   "forceAnchor": true,
   "iconProps": {
@@ -611,7 +611,7 @@ exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated ch
 }
 `;
 
-exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link with feature flag false 3`] = `
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as button with feature flag false 3`] = `
 {
   "displayedIndex": "0.1",
   "forceAnchor": true,
@@ -631,7 +631,7 @@ exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated ch
 }
 `;
 
-exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link with feature flag false 4`] = `
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as button with feature flag false 4`] = `
 {
   "displayedIndex": "0.2",
   "forceAnchor": true,
@@ -651,9 +651,151 @@ exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated ch
 }
 `;
 
-exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link with feature flag true 1`] = `
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as button with feature flag true 1`] = `
 {
   "forceAnchor": false,
+  "iconProps": {
+    "className": "hidden",
+  },
+  "index": 0,
+  "key": "Issues",
+  "name": "some title",
+  "onClickNavLink": [Function],
+  "onRenderNavLink": [Function],
+  "status": -2,
+  "testType": 1,
+  "title": "0: some title (passed)",
+  "url": "",
+}
+`;
+
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as link with feature flag false 1`] = `
+{
+  "forceAnchor": true,
+  "iconProps": {
+    "className": "hidden",
+  },
+  "index": 0,
+  "isExpanded": true,
+  "key": "Issues",
+  "links": [
+    {
+      "forceAnchor": true,
+      "iconProps": {
+        "className": "hidden",
+      },
+      "index": 0,
+      "key": "Issues: getting-started",
+      "name": "Getting started",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "testType": 1,
+      "url": "",
+    },
+    {
+      "displayedIndex": "0.1",
+      "forceAnchor": true,
+      "iconProps": {
+        "className": "hidden",
+      },
+      "index": 1,
+      "key": "Issues: requirement-key-1",
+      "name": "requirement-name-1",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "requirementKey": "requirement-key-1",
+      "status": -2,
+      "testType": 1,
+      "title": "0.1: requirement-name-1 (passed)",
+      "url": "",
+    },
+    {
+      "displayedIndex": "0.2",
+      "forceAnchor": true,
+      "iconProps": {
+        "className": "hidden",
+      },
+      "index": 2,
+      "key": "Issues: requirement-key-2",
+      "name": "requirement-name-2",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "requirementKey": "requirement-key-2",
+      "status": -2,
+      "testType": 1,
+      "title": "0.2: requirement-name-2 (passed)",
+      "url": "",
+    },
+  ],
+  "name": "some title",
+  "onClickNavLink": [Function],
+  "onRenderNavLink": [Function],
+  "status": -2,
+  "testType": 1,
+  "title": "0: some title (passed)",
+  "url": "",
+}
+`;
+
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as link with feature flag false 2`] = `
+{
+  "forceAnchor": true,
+  "iconProps": {
+    "className": "hidden",
+  },
+  "index": 0,
+  "key": "Issues: getting-started",
+  "name": "Getting started",
+  "onClickNavLink": [Function],
+  "onRenderNavLink": [Function],
+  "testType": 1,
+  "url": "",
+}
+`;
+
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as link with feature flag false 3`] = `
+{
+  "displayedIndex": "0.1",
+  "forceAnchor": true,
+  "iconProps": {
+    "className": "hidden",
+  },
+  "index": 1,
+  "key": "Issues: requirement-key-1",
+  "name": "requirement-name-1",
+  "onClickNavLink": [Function],
+  "onRenderNavLink": [Function],
+  "requirementKey": "requirement-key-1",
+  "status": -2,
+  "testType": 1,
+  "title": "0.1: requirement-name-1 (passed)",
+  "url": "",
+}
+`;
+
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as link with feature flag false 4`] = `
+{
+  "displayedIndex": "0.2",
+  "forceAnchor": true,
+  "iconProps": {
+    "className": "hidden",
+  },
+  "index": 2,
+  "key": "Issues: requirement-key-2",
+  "name": "requirement-name-2",
+  "onClickNavLink": [Function],
+  "onRenderNavLink": [Function],
+  "requirementKey": "requirement-key-2",
+  "status": -2,
+  "testType": 1,
+  "title": "0.2: requirement-name-2 (passed)",
+  "url": "",
+}
+`;
+
+exports[`LeftNavBuilder buildAutomatedChecksLinks should build just automated checks assessment link as link with feature flag true 1`] = `
+{
+  "forceAnchor": true,
   "iconProps": {
     "className": "hidden",
   },

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -196,9 +196,15 @@ describe('LeftNavBuilder', () => {
     });
 
     describe('buildAutomatedChecksLinks', () => {
-        it.each([true, false])(
-            'should build just automated checks assessment link with feature flag %s',
-            featureFlagState => {
+        it.each`
+            renderType  | featureFlagState | forceAnchor
+            ${'link'}   | ${true}          | ${true}
+            ${'button'} | ${false}         | ${false}
+            ${'button'} | ${true}          | ${false}
+            ${'link'}   | ${false}         | ${true}
+        `(
+            'should build just automated checks assessment link as $renderType with feature flag $featureFlagState',
+            ({ featureFlagState, forceAnchor }) => {
                 featureFlagStoreStateStub[FeatureFlags.automatedChecks] = featureFlagState;
 
                 const { expandedTest } = setupAssessmentMocks();
@@ -211,6 +217,7 @@ describe('LeftNavBuilder', () => {
                     expandedTest,
                     onRightPanelContentSwitchMock.object,
                     featureFlagStoreStateStub,
+                    forceAnchor,
                 );
                 expect(testLink).toMatchSnapshot();
                 if (featureFlagState) {

--- a/src/tests/unit/tests/DetailsView/components/left-nav/quick-assess-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/quick-assess-left-nav.test.tsx
@@ -112,6 +112,7 @@ describe(QuickAssessLeftNav.displayName, () => {
                     expandedTest,
                     onRightPanelContentSwitch,
                     {},
+                    true,
                 ),
             )
             .returns(() => automatedChecksLinkStub);


### PR DESCRIPTION
#### Details

The left nav for Assessments renders all Assessments as `button`s because most of them are collapsible and have requirement `link`s under them. Quick Assess' left nav renders all Requirements as `link`s since none are collapsible. The Automated Checks Assessment link used to be collapsible but is non-collapsible since the Automated Checks feature. However, the link is still rendered as a `button` for both Assessment and Quick Assess. This causes it to have noticeably different styling in Windows High Contrast mode. This PR renders the Automated Checks link as a `link` for Quick Assess.

| HC Theme | Quick Assess Before | Quick Assess After | Assessment Before | Assessment After |
-------------|------------------------|----------------------|----------------------|--------------------|
| Night Sky | ![quick assess left nav with all links purple but automated checks is yellow](https://github.com/microsoft/accessibility-insights-web/assets/3230904/f81a4d75-7e0e-42ee-a026-782745707837) | ![quick assess left nav with all links purple including automated checks](https://github.com/microsoft/accessibility-insights-web/assets/3230904/cad22840-b439-4205-b444-308278a75855) |  ![assessment left nav with all assessment links yellow](https://github.com/microsoft/accessibility-insights-web/assets/3230904/1523dc9e-adbc-4a49-b979-59a2e8b450cb) | ![assessment left nav with all assessment links yellow](https://github.com/microsoft/accessibility-insights-web/assets/3230904/d159055b-56a2-4096-a0e2-e332ed5c928b)
| Desert | ![quick assess left nav with all links blue but automated checks is black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/dadfee5d-7f34-4eef-b830-835d93b09fc3) | ![quick assess left nav with all links blue including automated checks](https://github.com/microsoft/accessibility-insights-web/assets/3230904/2184c2ce-5f86-43a9-be0a-e4bb1b74b72e) | ![assessment left nav with all assessment links black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/31483518-aef0-4c09-b94e-c5eed096f46c) | ![assessment left nav with all assessment links black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/4452f482-02c0-4844-b633-2892eb18b082)
| None | ![quick assess left nav with all links black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/d570fbb1-e101-417f-8c12-436977142096) | ![quick assess left nav with all links black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/4886b91e-ef67-4852-a6d8-6687e9776b44) | ![assessment left nav with all links black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/1032f8c6-2965-41c8-a5d1-5aeb487289f6) | ![assessment left nav with all links black](https://github.com/microsoft/accessibility-insights-web/assets/3230904/e133a3a3-062a-40c7-a510-f1a2cff0b158)

##### Motivation

fixes issue #6547 


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6547 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
