### PR TITLE
feat(quick-assess-ux): Remove Quick Assess feature flag

### DIFF
--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Dropdown, Icon, IDropdownOption, ResponsiveMode } from '@fluentui/react';
-import { FeatureFlags } from 'common/feature-flags';
 import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
 
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
@@ -16,7 +14,6 @@ export type SwitcherDeps = {
 export interface SwitcherProps {
     deps: SwitcherDeps;
     pivotKey: DetailsViewPivotType;
-    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export interface SwitcherState {
@@ -58,7 +55,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         );
     };
 
-    private getOptions = (featureFlagStoreData: FeatureFlagStoreData): IDropdownOption[] => {
+    private getOptions = (): IDropdownOption[] => {
         const fastPassConfig = {
             key: DetailsViewPivotType.fastPass,
             text: 'FastPass',
@@ -83,9 +80,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                 icon: 'testBeakerSolid',
             },
         };
-        return featureFlagStoreData[FeatureFlags.quickAssess]
-            ? [fastPassConfig, quickAssessConfig, assessmentConfig]
-            : [fastPassConfig, assessmentConfig];
+        return [fastPassConfig, quickAssessConfig, assessmentConfig];
     };
 
     public render(): JSX.Element {
@@ -99,7 +94,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                     onRenderOption={this.onRenderOption}
                     onRenderTitle={this.onRenderTitle}
                     onChange={this.onOptionChange}
-                    options={this.getOptions(this.props.featureFlagStoreData)}
+                    options={this.getOptions()}
                 />
             </div>
         );

--- a/src/common/components/hamburger-menu-button.tsx
+++ b/src/common/components/hamburger-menu-button.tsx
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 import { ContextualMenuItemType, IconButton, IContextualMenuItem } from '@fluentui/react';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC } from 'common/react/named-fc';
 import { DetailsViewPivotType } from 'common/types/store-data/details-view-pivot-type';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
 import { LaunchPanelHeader } from 'popup/components/launch-panel-header';
@@ -24,13 +22,12 @@ export type HamburgerMenuButtonProps = {
     deps: HamburgerMenuButtonDeps;
     popupWindow: Window;
     header: LaunchPanelHeader;
-    featureFlagData: FeatureFlagStoreData;
 };
 
 export const HamburgerMenuButton = NamedFC<HamburgerMenuButtonProps>(
     'HamburgerMenuButton',
     props => {
-        const { deps, header, popupWindow, featureFlagData } = props;
+        const { deps, header, popupWindow } = props;
         const { launchPanelHeaderClickHandler, popupActionMessageCreator } = deps;
         const fastPassMenuItem = {
             key: 'fast-pass',
@@ -82,9 +79,12 @@ export const HamburgerMenuButton = NamedFC<HamburgerMenuButtonProps>(
             name: 'Ad hoc tools',
             onClick: () => launchPanelHeaderClickHandler.openAdhocToolsPanel(header),
         };
-        const productMenuItems = featureFlagData[FeatureFlags.quickAssess]
-            ? [fastPassMenuItem, quickAssessMenuItem, assessmentMenuItem, adhocToolsMenuItem]
-            : [fastPassMenuItem, assessmentMenuItem, adhocToolsMenuItem];
+        const productMenuItems = [
+            fastPassMenuItem,
+            quickAssessMenuItem,
+            assessmentMenuItem,
+            adhocToolsMenuItem,
+        ];
 
         const resourceMenuItems: IContextualMenuItem[] = [
             {

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -13,7 +13,6 @@ export class FeatureFlags {
     public static readonly manualInstanceDetails = 'manualInstanceDetails';
     public static readonly debugTools = 'debugTools';
     public static readonly exportReportOptions = 'exportReportOptions';
-    public static readonly quickAssess = 'quickAssess';
     public static readonly automatedChecks = 'automatedChecks';
 }
 
@@ -96,14 +95,6 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             defaultValue: false,
             displayableName: 'More export options',
             displayableDescription: 'Enables exporting reports to external services',
-            isPreviewFeature: true,
-            forceDefault: false,
-        },
-        {
-            id: FeatureFlags.quickAssess,
-            defaultValue: false,
-            displayableName: 'Quick Assess',
-            displayableDescription: 'Adds Quick Assess option to launch pad and details view pivot',
             isPreviewFeature: true,
             forceDefault: false,
         },

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -150,7 +150,6 @@ export class PopupView extends React.Component<PopupViewProps> {
                 this,
                 popupActionMessageCreator,
                 this.props.popupHandlers.popupViewControllerHandler,
-                this.props.storeState.featureFlagStoreData,
             );
 
         const onClickTutorialLink = event => popupActionMessageCreator.openTutorial(event);

--- a/src/popup/launch-pad-row-configuration-factory.ts
+++ b/src/popup/launch-pad-row-configuration-factory.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FeatureFlags } from 'common/feature-flags';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TelemetryEventSource } from '../common/extension-telemetry-events';
 import { DetailsViewPivotType } from '../common/types/store-data/details-view-pivot-type';
 import { VisualizationType } from '../common/types/visualization-type';
@@ -15,7 +13,6 @@ export class LaunchPadRowConfigurationFactory {
         component: PopupView,
         actionMessageCreator: PopupActionMessageCreator,
         handler: PopupViewControllerHandler,
-        featureFlagStoreData: FeatureFlagStoreData,
     ): LaunchPadRowConfiguration[] {
         const fastPassRowConfig = {
             iconName: 'Rocket',
@@ -62,8 +59,6 @@ export class LaunchPadRowConfigurationFactory {
                 ),
         };
 
-        return featureFlagStoreData[FeatureFlags.quickAssess]
-            ? [fastPassRowConfig, quickAssessRowConfig, assessmentRowConfig, adhocRowConfig]
-            : [fastPassRowConfig, assessmentRowConfig, adhocRowConfig];
+        return [fastPassRowConfig, quickAssessRowConfig, assessmentRowConfig, adhocRowConfig];
     }
 }

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -130,53 +130,6 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                     Enables exporting reports to external services
                   </div>
                 </div>
-                <div
-                  class="generic-toggle-component--{{CSS_MODULE_HASH}}"
-                >
-                  <div
-                    class="toggle-container--{{CSS_MODULE_HASH}}"
-                  >
-                    <div
-                      class="toggle-name--{{CSS_MODULE_HASH}}"
-                    >
-                      Quick Assess
-                    </div>
-                    <div
-                      class="ms-Toggle is-enabled toggle--{{CSS_MODULE_HASH}} root-000"
-                    >
-                      <div
-                        class="ms-Toggle-innerContainer container-000"
-                      >
-                        <button
-                          aria-checked="false"
-                          aria-label="Quick Assess"
-                          class="ms-Toggle-background pill-000"
-                          data-is-focusable="true"
-                          data-ktp-target="true"
-                          id="quickAssess"
-                          role="switch"
-                          type="button"
-                        >
-                          <span
-                            class="ms-Toggle-thumb thumb-000"
-                          />
-                        </button>
-                        <label
-                          class="ms-Label ms-Toggle-stateText text-000"
-                          for="quickAssess"
-                          id="quickAssess-stateText"
-                        >
-                          Off
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="toggle-description--{{CSS_MODULE_HASH}}"
-                  >
-                    Adds Quick Assess option to launch pad and details view pivot
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
@@ -23,7 +23,7 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
           <button
             aria-disabled="false"
             aria-posinset="1"
-            aria-setsize="6"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="FastPass"
             role="menuitem"
@@ -54,7 +54,38 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
           <button
             aria-disabled="false"
             aria-posinset="2"
-            aria-setsize="6"
+            aria-setsize="7"
+            class="ms-ContextualMenu-link root-000"
+            name="Quick Assess"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="ms-ContextualMenu-linkContent linkContent-000"
+            >
+              <i
+                aria-hidden="true"
+                class="ms-ContextualMenu-icon icon-000"
+                data-icon-name="SiteScan"
+              >
+                
+              </i>
+              <span
+                class="ms-ContextualMenu-itemText label-000"
+              >
+                Quick Assess
+              </span>
+            </div>
+          </button>
+        </li>
+        <li
+          class="ms-ContextualMenu-item item-000"
+          role="presentation"
+        >
+          <button
+            aria-disabled="false"
+            aria-posinset="3"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Assessment"
             role="menuitem"
@@ -84,8 +115,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
         >
           <button
             aria-disabled="false"
-            aria-posinset="3"
-            aria-setsize="6"
+            aria-posinset="4"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Ad hoc tools"
             role="menuitem"
@@ -120,8 +151,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
         >
           <button
             aria-disabled="false"
-            aria-posinset="4"
-            aria-setsize="6"
+            aria-posinset="5"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Keyboard shortcuts"
             role="menuitem"
@@ -151,8 +182,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
         >
           <button
             aria-disabled="false"
-            aria-posinset="5"
-            aria-setsize="6"
+            aria-posinset="6"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Third party notices"
             role="menuitem"
@@ -182,8 +213,8 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
         >
           <button
             aria-disabled="false"
-            aria-posinset="6"
-            aria-setsize="6"
+            aria-posinset="7"
+            aria-setsize="7"
             class="ms-ContextualMenu-link root-000"
             name="Help"
             role="menuitem"
@@ -271,6 +302,7 @@ exports[`Popup -> Hamburger menu should have content matching snapshot when quic
             class="ms-ContextualMenu-link root-000"
             name="Quick Assess"
             role="menuitem"
+            tabindex="-1"
           >
             <div
               class="ms-ContextualMenu-linkContent linkContent-000"

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -146,6 +146,48 @@ exports[`Popup -> Launch Pad content should match snapshot when quick assess fea
                   <i
                     aria-hidden="true"
                     class="popup-start-dialog-icon root-000"
+                    data-icon-name="SiteScan"
+                  >
+                    
+                  </i>
+                </div>
+                <div>
+                  <div
+                    class="launch-pad-item-title"
+                  >
+                    <button
+                      aria-describedby="launch-pad-item-description-2"
+                      class="ms-Link insights-link root-000"
+                      id="quick-assess"
+                      role="link"
+                      type="button"
+                    >
+                      Quick Assess
+                    </button>
+                  </div>
+                  <div
+                    class="launch-pad-item-description"
+                    id="launch-pad-item-description-000"
+                  >
+                    Run 10 assisted checks to find more accessibility issues in 30 minutes.
+                  </div>
+                </div>
+              </div>
+              <hr
+                class="ms-fontColor-neutralTertiaryAlt launch-pad-hr"
+              />
+            </div>
+            <div>
+              <div
+                class="launch-pad-item-grid"
+              >
+                <div
+                  aria-hidden="true"
+                  class="popup-start-dialog-icon-circle"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="popup-start-dialog-icon root-000"
                     data-icon-name="testBeaker"
                   >
                     
@@ -156,7 +198,7 @@ exports[`Popup -> Launch Pad content should match snapshot when quick assess fea
                     class="launch-pad-item-title"
                   >
                     <button
-                      aria-describedby="launch-pad-item-description-2"
+                      aria-describedby="launch-pad-item-description-3"
                       class="ms-Link insights-link root-000"
                       id="assessment"
                       role="link"
@@ -198,7 +240,7 @@ exports[`Popup -> Launch Pad content should match snapshot when quick assess fea
                     class="launch-pad-item-title"
                   >
                     <button
-                      aria-describedby="launch-pad-item-description-3"
+                      aria-describedby="launch-pad-item-description-4"
                       class="ms-Link insights-link root-000"
                       id="ad-hoc-tools"
                       role="link"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -29,113 +29,13 @@ exports[`Switcher props dropdown has correct options 1`] = `
 ]
 `;
 
-exports[`Switcher props dropdown has correct options when quick assess feature flag is false 1`] = `
-[
-  {
-    "data": {
-      "icon": "Rocket",
-    },
-    "key": 0,
-    "text": "FastPass",
-    "title": "FastPass",
-  },
-  {
-    "data": {
-      "icon": "SiteScan",
-    },
-    "key": 3,
-    "text": "Quick Assess",
-    "title": "Quick Assess",
-  },
-  {
-    "data": {
-      "icon": "testBeakerSolid",
-    },
-    "key": 2,
-    "text": "Assessment",
-    "title": "Assessment",
-  },
-]
-`;
-
-exports[`Switcher props dropdown has correct options when quick assess feature flag is true 1`] = `
-[
-  {
-    "data": {
-      "icon": "Rocket",
-    },
-    "key": 0,
-    "text": "FastPass",
-    "title": "FastPass",
-  },
-  {
-    "data": {
-      "icon": "SiteScan",
-    },
-    "key": 3,
-    "text": "Quick Assess",
-    "title": "Quick Assess",
-  },
-  {
-    "data": {
-      "icon": "testBeakerSolid",
-    },
-    "key": 2,
-    "text": "Assessment",
-    "title": "Assessment",
-  },
-]
-`;
-
 exports[`Switcher renders Switcher itself matches snapshot 1`] = `
 "<div className="leftNavSwitcher" role="region" aria-label="activity">
   <Dropdown className="leftNavSwitcherDropdown" ariaLabel="select activity" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
 </div>"
 `;
 
-exports[`Switcher renders Switcher itself matches snapshot when quick assess feature flag is false 1`] = `
-"<div className="leftNavSwitcher" role="region" aria-label="activity">
-  <Dropdown className="leftNavSwitcherDropdown" ariaLabel="select activity" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
-</div>"
-`;
-
-exports[`Switcher renders Switcher itself matches snapshot when quick assess feature flag is true 1`] = `
-"<div className="leftNavSwitcher" role="region" aria-label="activity">
-  <Dropdown className="leftNavSwitcherDropdown" ariaLabel="select activity" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
-</div>"
-`;
-
 exports[`Switcher renders option renderer override matches snapshot 1`] = `
-<span
-  className="switcherDropdownOption"
->
-  <Memo(Icon)
-    iconName="Rocket"
-  />
-  <span
-    data-automation-id="switcher-option"
-  >
-    FastPass
-  </span>
-</span>
-`;
-
-exports[`Switcher renders option renderer override matches snapshotm when quick assess feature flag is false 1`] = `
-<span
-  className="switcherDropdownOption"
->
-  <Memo(Icon)
-    iconName="Rocket"
-  />
-  <span
-    data-automation-id="switcher-option"
-  >
-    FastPass
-  </span>
-</span>
-`;
-
-exports[`Switcher renders option renderer override matches snapshotm when quick assess feature flag is true 1`] = `
 <span
   className="switcherDropdownOption"
 >

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Switcher props dropdown has correct options 1`] = `
+[
+  {
+    "data": {
+      "icon": "Rocket",
+    },
+    "key": 0,
+    "text": "FastPass",
+    "title": "FastPass",
+  },
+  {
+    "data": {
+      "icon": "SiteScan",
+    },
+    "key": 3,
+    "text": "Quick Assess",
+    "title": "Quick Assess",
+  },
+  {
+    "data": {
+      "icon": "testBeakerSolid",
+    },
+    "key": 2,
+    "text": "Assessment",
+    "title": "Assessment",
+  },
+]
+`;
+
 exports[`Switcher props dropdown has correct options when quick assess feature flag is false 1`] = `
 [
   {
@@ -9,6 +38,14 @@ exports[`Switcher props dropdown has correct options when quick assess feature f
     "key": 0,
     "text": "FastPass",
     "title": "FastPass",
+  },
+  {
+    "data": {
+      "icon": "SiteScan",
+    },
+    "key": 3,
+    "text": "Quick Assess",
+    "title": "Quick Assess",
   },
   {
     "data": {
@@ -50,6 +87,12 @@ exports[`Switcher props dropdown has correct options when quick assess feature f
 ]
 `;
 
+exports[`Switcher renders Switcher itself matches snapshot 1`] = `
+"<div className="leftNavSwitcher" role="region" aria-label="activity">
+  <Dropdown className="leftNavSwitcherDropdown" ariaLabel="select activity" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
+</div>"
+`;
+
 exports[`Switcher renders Switcher itself matches snapshot when quick assess feature flag is false 1`] = `
 "<div className="leftNavSwitcher" role="region" aria-label="activity">
   <Dropdown className="leftNavSwitcherDropdown" ariaLabel="select activity" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
@@ -60,6 +103,21 @@ exports[`Switcher renders Switcher itself matches snapshot when quick assess fea
 "<div className="leftNavSwitcher" role="region" aria-label="activity">
   <Dropdown className="leftNavSwitcherDropdown" ariaLabel="select activity" responsiveMode={2} selectedKey={0} onRenderOption={[Function (anonymous)]} onRenderTitle={[Function (anonymous)]} onChange={[Function (anonymous)]} options={{...}} />
 </div>"
+`;
+
+exports[`Switcher renders option renderer override matches snapshot 1`] = `
+<span
+  className="switcherDropdownOption"
+>
+  <Memo(Icon)
+    iconName="Rocket"
+  />
+  <span
+    data-automation-id="switcher-option"
+  >
+    FastPass
+  </span>
+</span>
 `;
 
 exports[`Switcher renders option renderer override matches snapshotm when quick assess feature flag is false 1`] = `

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -11,7 +11,6 @@ import { IMock, Mock, Times } from 'typemoq';
 describe('Switcher', () => {
     let defaultProps: SwitcherProps;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    const quickAssessFeatureFlag = 'quickAssess';
 
     beforeEach(() => {
         detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
@@ -20,52 +19,37 @@ describe('Switcher', () => {
             deps: {
                 detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
             },
-            featureFlagStoreData: {},
         };
     });
 
     describe('renders', () => {
-        it.each([true, false])(
-            'Switcher itself matches snapshot when quick assess feature flag is %s',
-            featureFlagValue => {
-                defaultProps.featureFlagStoreData[quickAssessFeatureFlag] = featureFlagValue;
-                const renderer = shallow(<Switcher {...defaultProps} />);
+        it('Switcher itself matches snapshot', () => {
+            const renderer = shallow(<Switcher {...defaultProps} />);
 
-                expect(renderer.debug()).toMatchSnapshot();
-            },
-        );
+            expect(renderer.debug()).toMatchSnapshot();
+        });
 
-        it.each([true, false])(
-            'option renderer override matches snapshotm when quick assess feature flag is %s',
-            featureFlagValue => {
-                defaultProps.featureFlagStoreData[quickAssessFeatureFlag] = featureFlagValue;
+        it('option renderer override matches snapshot', () => {
+            const renderer = shallow(<Switcher {...defaultProps} />);
 
-                const renderer = shallow(<Switcher {...defaultProps} />);
+            const dropdown = renderer.find(Dropdown);
 
-                const dropdown = renderer.find(Dropdown);
+            const options = dropdown.prop('options');
 
-                const options = dropdown.prop('options');
+            const onRenderOption = dropdown.prop('onRenderOption');
 
-                const onRenderOption = dropdown.prop('onRenderOption');
-
-                expect(onRenderOption(options[0])).toMatchSnapshot();
-            },
-        );
+            expect(onRenderOption(options[0])).toMatchSnapshot();
+        });
     });
 
     describe('props', () => {
-        it.each([true, false])(
-            'dropdown has correct options when quick assess feature flag is %s',
-            featureFlagValue => {
-                defaultProps.featureFlagStoreData[quickAssessFeatureFlag] = featureFlagValue;
+        it('dropdown has correct options', () => {
+            const renderer = shallow(<Switcher {...defaultProps} />);
 
-                const renderer = shallow(<Switcher {...defaultProps} />);
+            const dropdown = renderer.find(Dropdown);
 
-                const dropdown = renderer.find(Dropdown);
-
-                expect(dropdown.prop('options')).toMatchSnapshot();
-            },
-        );
+            expect(dropdown.prop('options')).toMatchSnapshot();
+        });
     });
 
     describe('user interaction', () => {

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -25,7 +25,6 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
-            [FeatureFlags.quickAssess]: false,
             [FeatureFlags.automatedChecks]: true,
         };
 

--- a/src/tests/unit/tests/common/components/__snapshots__/hamburger-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/hamburger-menu-button.test.tsx.snap
@@ -25,6 +25,14 @@ exports[`HamburgerMenuButton renders proper button and menu item props 1`] = `
         },
         {
           "iconProps": {
+            "iconName": "SiteScan",
+          },
+          "key": "quick-assess",
+          "name": "Quick Assess",
+          "onClick": [Function],
+        },
+        {
+          "iconProps": {
             "iconName": "testBeakerSolid",
           },
           "key": "assessment",

--- a/src/tests/unit/tests/common/components/hamburger-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/hamburger-menu-button.test.tsx
@@ -28,7 +28,6 @@ describe('HamburgerMenuButton', () => {
             deps,
             header: Mock.ofType(LaunchPanelHeader).object,
             popupWindow: Mock.ofType<Window>().object,
-            featureFlagData: {},
         };
 
         it('proper button and menu item props', () => {
@@ -41,22 +40,6 @@ describe('HamburgerMenuButton', () => {
             const testSubject = wrapped.find<IButtonProps>(IconButton).prop('onRenderMenuIcon');
 
             expect(testSubject()).toBeNull();
-        });
-
-        it('does not render quick-assess menu item if feature flag is false', () => {
-            props.featureFlagData = { quickAssess: false };
-            const wrapped = shallow(<HamburgerMenuButton {...props} />);
-            const testSubject = wrapped.find<IButtonProps>(IconButton).prop('menuProps').items;
-
-            expect(testSubject.find(item => item.key === 'quick-assess')).toBeUndefined();
-        });
-
-        it('renders quick-assess menu item if feature flag is true', () => {
-            props.featureFlagData = { quickAssess: true };
-            const wrapped = shallow(<HamburgerMenuButton {...props} />);
-            const testSubject = wrapped.find<IButtonProps>(IconButton).prop('menuProps').items;
-
-            expect(testSubject.find(item => item.key === 'quick-assess')).toBeDefined();
         });
     });
 
@@ -82,7 +65,6 @@ describe('HamburgerMenuButton', () => {
                 },
                 header: headerMock.object,
                 popupWindow: popupWindowMock.object,
-                featureFlagData: { quickAssess: true },
             };
 
             const testObject = shallow(<HamburgerMenuButton {...props} />);

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -98,7 +98,6 @@ describe('PopupView', () => {
                         It.isAny(),
                         IsSameObject(actionMessageCreatorStrictMock.object),
                         IsSameObject(handlerMock.object),
-                        It.isAny(),
                     ),
                 )
                 .returns(() => rowConfigStub as any)


### PR DESCRIPTION
#### Details

This PR makes sure that Quick Assess appears as part of the extension by default!

| | Preview Features | Launch Pad |
|-|-|-|
| Before | ![preview features pane with Quick Assess toggle present](https://github.com/microsoft/accessibility-insights-web/assets/3230904/d52c868c-0771-409d-83df-012c249f7477) | <img width="344" alt="launch pad showing three options: FastPass, Assessment, and Ad hoc tools" src="https://github.com/microsoft/accessibility-insights-web/assets/3230904/0be27482-b2e1-4739-94ad-5dd95ad7861a">
| After | ![preview features pane with no Quick Assess toggle](https://github.com/microsoft/accessibility-insights-web/assets/3230904/26c779e1-60a9-458c-a3d3-9772198d8900) | <img width="344" alt="launch pad showing four options: FastPass, Quick Assess, Assessment, and Ad hoc tools" src="https://github.com/microsoft/accessibility-insights-web/assets/3230904/8dc23976-3cea-48f7-b54d-a494c75244fa">


##### Motivation

feature work

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
