### PR TITLE
chore: Remove inline snapshots

### DIFF
--- a/src/tests/unit/common/__snapshots__/application-properties-provider.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/application-properties-provider.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createToolData returns proper tool data 1`] = `
+{
+  "applicationProperties": {
+    "environmentName": "test-environment-name",
+    "name": "test-tool-name",
+    "resolution": "test-resolution",
+    "version": "test-tool-version",
+  },
+  "scanEngineProperties": {
+    "name": "test-engine-name",
+    "version": "test-engine-version",
+  },
+}
+`;

--- a/src/tests/unit/common/application-properties-provider.test.ts
+++ b/src/tests/unit/common/application-properties-provider.test.ts
@@ -13,19 +13,6 @@ describe('createToolData', () => {
             'test-resolution',
         );
 
-        expect(result).toMatchInlineSnapshot(`
-            {
-              "applicationProperties": {
-                "environmentName": "test-environment-name",
-                "name": "test-tool-name",
-                "resolution": "test-resolution",
-                "version": "test-tool-version",
-              },
-              "scanEngineProperties": {
-                "name": "test-engine-name",
-                "version": "test-engine-version",
-              },
-            }
-        `);
+        expect(result).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/background/__snapshots__/background-message-distributor.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/background-message-distributor.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BackgroundMessageDistributor with unrecognized messages should emit a rejected promise describing the unrecognized message 1`] = `"Unable to interpret message - {"payload":"test-payload"}"`;

--- a/src/tests/unit/tests/background/background-message-distributor.test.ts
+++ b/src/tests/unit/tests/background/background-message-distributor.test.ts
@@ -192,9 +192,7 @@ describe(BackgroundMessageDistributor, () => {
             const response = distributeMessageCallback(message);
 
             expect(response.messageHandled).toBe(true);
-            await expect(response.result).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"Unable to interpret message - {"payload":"test-payload"}"`,
-            );
+            await expect(response.result).rejects.toThrowErrorMatchingSnapshot();
         });
     });
 

--- a/src/tests/unit/tests/common/__snapshots__/store-update-message-hub.test.ts.snap
+++ b/src/tests/unit/tests/common/__snapshots__/store-update-message-hub.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StoreUpdateMessageHub Errors if a store update listener is registered before the hub's listener 1`] = `"StoreUpdateMessageHub.browserMessageHandler must be registered as a browser listener *before* registering individual store update listeners to avoid missing store state initialization messages"`;

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BackgroundBrowserEventManager times out if no ApplicationListener registers in time 1`] = `
+[
+  "Error while processing browser event-type event: ",
+  "[deferred browser event: {"eventType":"event-type","eventArgs":[]}]",
+]
+`;

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -13,3 +13,10 @@ exports[`BackgroundBrowserEventManager times out late-registered Promise-based A
   "[deferred browser event: {"eventType":"event-type","eventArgs":[]}]",
 ]
 `;
+
+exports[`BackgroundBrowserEventManager times out pre-registered Promise-based ApplicationListeners 1`] = `
+[
+  "Error while processing browser event-type event: ",
+  "[browser event listener: {"eventType":"event-type","eventArgs":[]}]",
+]
+`;

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BackgroundBrowserEventManager does not allow ApplicationListener added for an event that does not have a browser listener 1`] = `"No browser listener was pre-registered for event-type"`;
+
 exports[`BackgroundBrowserEventManager does not allow multiple registrations for the same event type 1`] = `"Listener already registered for event-type"`;
 
 exports[`BackgroundBrowserEventManager logs an error and propagates sync value-returning ApplicationListeners 1`] = `"Unexpected sync ApplicationListener for browser event-type event: "`;

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`BackgroundBrowserEventManager logs an error and propagates sync value-returning ApplicationListeners 1`] = `"Unexpected sync ApplicationListener for browser event-type event: "`;
 
+exports[`BackgroundBrowserEventManager logs and eats an error for throwing ApplicationListeners 1`] = `"Error thrown from ApplicationListener for browser event-type event: "`;
+
 exports[`BackgroundBrowserEventManager times out if no ApplicationListener registers in time 1`] = `
 [
   "Error while processing browser event-type event: ",

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BackgroundBrowserEventManager does not allow multiple registrations for the same event type 1`] = `"Listener already registered for event-type"`;
+
 exports[`BackgroundBrowserEventManager logs an error and propagates sync value-returning ApplicationListeners 1`] = `"Unexpected sync ApplicationListener for browser event-type event: "`;
 
 exports[`BackgroundBrowserEventManager logs and eats an error for Promise-based ApplicationListeners which reject 1`] = `"Error while processing browser event-type event: "`;

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BackgroundBrowserEventManager logs an error and propagates sync value-returning ApplicationListeners 1`] = `"Unexpected sync ApplicationListener for browser event-type event: "`;
+
 exports[`BackgroundBrowserEventManager times out if no ApplicationListener registers in time 1`] = `
 [
   "Error while processing browser event-type event: ",

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -6,3 +6,10 @@ exports[`BackgroundBrowserEventManager times out if no ApplicationListener regis
   "[deferred browser event: {"eventType":"event-type","eventArgs":[]}]",
 ]
 `;
+
+exports[`BackgroundBrowserEventManager times out late-registered Promise-based ApplicationListeners 1`] = `
+[
+  "Error while processing browser event-type event: ",
+  "[deferred browser event: {"eventType":"event-type","eventArgs":[]}]",
+]
+`;

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/background-browser-event-manager.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`BackgroundBrowserEventManager logs an error and propagates sync value-returning ApplicationListeners 1`] = `"Unexpected sync ApplicationListener for browser event-type event: "`;
 
+exports[`BackgroundBrowserEventManager logs and eats an error for Promise-based ApplicationListeners which reject 1`] = `"Error while processing browser event-type event: "`;
+
 exports[`BackgroundBrowserEventManager logs and eats an error for throwing ApplicationListeners 1`] = `"Error thrown from ApplicationListener for browser event-type event: "`;
 
 exports[`BackgroundBrowserEventManager times out if no ApplicationListener registers in time 1`] = `

--- a/src/tests/unit/tests/common/browser-adapters/__snapshots__/passthrough-browser-event-manager.test.ts.snap
+++ b/src/tests/unit/tests/common/browser-adapters/__snapshots__/passthrough-browser-event-manager.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PassthroughBrowserEventManager addApplicationListener does not allow multiple registrations for the same event type 1`] = `"Listener already registered for event-type"`;

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -258,9 +258,7 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(timeSimulatingPromiseFactory.elapsedTime).toBe(0);
         expect(recordingLogger.errorRecords).toHaveLength(1);
-        expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
-            `"Error while processing browser event-type event: "`,
-        );
+        expect(recordingLogger.errorRecords[0].message).toMatchSnapshot();
         expect(recordingLogger.errorRecords[0].optionalParams[0]).toBe(appListenerError);
     });
 

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -243,9 +243,7 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(timeSimulatingPromiseFactory.elapsedTime).toBe(0);
         expect(recordingLogger.errorRecords).toHaveLength(1);
-        expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
-            `"Error thrown from ApplicationListener for browser event-type event: "`,
-        );
+        expect(recordingLogger.errorRecords[0].message).toMatchSnapshot();
         expect(recordingLogger.errorRecords[0].optionalParams[0]).toBe(appListenerError);
     });
 

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -180,14 +180,10 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
-        expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
-            `"Error while processing browser event-type event: "`,
-        );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot(
-            `"[deferred browser event: {"eventType":"event-type","eventArgs":[]}]"`,
-        );
+        const snapshot = [recordingLogger.errorRecords[0].message, loggedError.context];
+        expect(snapshot).toMatchSnapshot();
 
         stalledAppListenerResponse.resolveHook(null); // test cleanup, avoids Promise leak
     });

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -150,14 +150,11 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
-        expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
-            `"Error while processing browser event-type event: "`,
-        );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot(
-            `"[deferred browser event: {"eventType":"event-type","eventArgs":[]}]"`,
-        );
+
+        const snapshot = [recordingLogger.errorRecords[0].message, loggedError.context];
+        expect(snapshot).toMatchSnapshot();
 
         let appListenerFired = false;
         testSubject.addApplicationListener('event-type', testEvent, () => {

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -224,9 +224,7 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(timeSimulatingPromiseFactory.elapsedTime).toBe(0);
         expect(recordingLogger.errorRecords).toHaveLength(1);
-        expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
-            `"Unexpected sync ApplicationListener for browser event-type event: "`,
-        );
+        expect(recordingLogger.errorRecords[0].message).toMatchSnapshot();
         expect(recordingLogger.errorRecords[0].optionalParams[0]).toBe(syncAppListener);
         expect(recordingLogger.errorRecords[0].optionalParams[1]).toStrictEqual([
             'event-arg-1',

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -278,9 +278,7 @@ describe(BackgroundBrowserEventManager, () => {
                 testEvent,
                 async () => 'app listener result',
             );
-        }).toThrowErrorMatchingInlineSnapshot(
-            `"No browser listener was pre-registered for event-type"`,
-        );
+        }).toThrowErrorMatchingSnapshot();
     });
 
     describe('removeListener', () => {

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -205,14 +205,10 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(timeSimulatingPromiseFactory.elapsedTime).toBe(60000);
         expect(recordingLogger.errorRecords).toHaveLength(1);
-        expect(recordingLogger.errorRecords[0].message).toMatchInlineSnapshot(
-            `"Error while processing browser event-type event: "`,
-        );
         const loggedError = recordingLogger.errorRecords[0].optionalParams[0];
         expect(loggedError).toBeInstanceOf(TimeoutError);
-        expect(loggedError.context).toMatchInlineSnapshot(
-            `"[browser event listener: {"eventType":"event-type","eventArgs":[]}]"`,
-        );
+        const snapshot = [recordingLogger.errorRecords[0].message, loggedError.context];
+        expect(snapshot).toMatchSnapshot();
 
         stalledAppListenerResponse.resolveHook(null); // test cleanup, avoids Promise leak
     });

--- a/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/background-browser-event-manager.test.ts
@@ -268,7 +268,7 @@ describe(BackgroundBrowserEventManager, () => {
 
         expect(() => {
             testSubject.addApplicationListener('event-type', testEvent, () => {});
-        }).toThrowErrorMatchingInlineSnapshot(`"Listener already registered for event-type"`);
+        }).toThrowErrorMatchingSnapshot();
     });
 
     it('does not allow ApplicationListener added for an event that does not have a browser listener', async () => {

--- a/src/tests/unit/tests/common/browser-adapters/passthrough-browser-event-manager.test.ts
+++ b/src/tests/unit/tests/common/browser-adapters/passthrough-browser-event-manager.test.ts
@@ -28,7 +28,7 @@ describe(PassthroughBrowserEventManager, () => {
 
             expect(() => {
                 testSubject.addApplicationListener('event-type', testEvent, () => {});
-            }).toThrowErrorMatchingInlineSnapshot(`"Listener already registered for event-type"`);
+            }).toThrowErrorMatchingSnapshot();
         });
     });
 

--- a/src/tests/unit/tests/common/promises/__snapshots__/promise-factory.test.ts.snap
+++ b/src/tests/unit/tests/common/promises/__snapshots__/promise-factory.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`promiseFactory timeout rejects with the pinned error message on timeout 1`] = `"Timed out after 1ms"`;

--- a/src/tests/unit/tests/common/promises/__snapshots__/promise-factory.test.ts.snap
+++ b/src/tests/unit/tests/common/promises/__snapshots__/promise-factory.test.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`promiseFactory timeout rejects with the pinned error message on timeout 1`] = `"Timed out after 1ms"`;
+
+exports[`promiseFactory timeout rejects with the pinned error message on timeout with error context 1`] = `"Timed out after 1ms at context test-error-context"`;

--- a/src/tests/unit/tests/common/promises/promise-factory.test.ts
+++ b/src/tests/unit/tests/common/promises/promise-factory.test.ts
@@ -45,9 +45,7 @@ describe(`promiseFactory`, () => {
             const delay = 1;
             const timingOut = testObject.timeout(neverResolveAsync(), delay);
 
-            await expect(timingOut).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"Timed out after 1ms"`,
-            );
+            await expect(timingOut).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it('rejects with the pinned error message on timeout with error context', async () => {

--- a/src/tests/unit/tests/common/promises/promise-factory.test.ts
+++ b/src/tests/unit/tests/common/promises/promise-factory.test.ts
@@ -52,9 +52,7 @@ describe(`promiseFactory`, () => {
             const delay = 1;
             const timingOut = testObject.timeout(neverResolveAsync(), delay, 'test-error-context');
 
-            await expect(timingOut).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"Timed out after 1ms at context test-error-context"`,
-            );
+            await expect(timingOut).rejects.toThrowErrorMatchingSnapshot();
         });
     });
 

--- a/src/tests/unit/tests/common/store-update-message-hub.test.ts
+++ b/src/tests/unit/tests/common/store-update-message-hub.test.ts
@@ -115,9 +115,7 @@ describe(StoreUpdateMessageHub, () => {
 
         expect(() =>
             testSubject.registerStoreUpdateListener(storeId, registeredListener),
-        ).toThrowErrorMatchingInlineSnapshot(
-            `"StoreUpdateMessageHub.browserMessageHandler must be registered as a browser listener *before* registering individual store update listeners to avoid missing store state initialization messages"`,
-        );
+        ).toThrowErrorMatchingSnapshot();
     });
 
     it('Calls registered listener if not created with a tab id', async () => {

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -12,6 +12,12 @@ exports[`AxeFrameMessenger post/open communication does not invoke closed topic 
 ]
 `;
 
+exports[`AxeFrameMessenger post/open communication logs an error and continues if a replyHandler attempts to reply to a reply 1`] = `
+[
+  "AxeFrameMessenger does not support replies-to-replies, but a post replyHandler invoked a responder.",
+]
+`;
+
 exports[`AxeFrameMessenger post/open communication logs an error and noops if a replyHandler throws 1`] = `
 [
   "An axe-core error occurred while processing a result from a child frame.",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AxeFrameMessenger post/open communication does not accept messages that originate from non-parent windows 1`] = `
+[
+  "Received unexpected axe-core message from a non-parent window",
+]
+`;
+
 exports[`AxeFrameMessenger post/open communication does not invoke closed topic handlers 1`] = `
 [
   "Error while attempting to send axe-core frameMessenger message: target window reachable, but is not listening for command axe.frameMessenger.post",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AxeFrameMessenger post/open communication does not invoke closed topic handlers 1`] = `
+[
+  "Error while attempting to send axe-core frameMessenger message: target window reachable, but is not listening for command axe.frameMessenger.post",
+]
+`;
+
 exports[`AxeFrameMessenger post/open communication logs an error if the underlying communicator fails 1`] = `
 [
   "Error while attempting to send axe-core frameMessenger message: target window unreachable (LinkedRespondableCommunicator not linked to it)",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -18,6 +18,12 @@ exports[`AxeFrameMessenger post/open communication logs an error and continues i
 ]
 `;
 
+exports[`AxeFrameMessenger post/open communication logs an error and continues if a topicHandler attempts support handling replies-to-replies 1`] = `
+[
+  "AxeFrameMessenger does not support replies-to-replies, but a topicHandler provided a replyHandler in a response callback.",
+]
+`;
+
 exports[`AxeFrameMessenger post/open communication logs an error and noops if a replyHandler throws 1`] = `
 [
   "An axe-core error occurred while processing a result from a child frame.",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AxeFrameMessenger post/open communication logs an error if the underlying communicator fails 1`] = `
+[
+  "Error while attempting to send axe-core frameMessenger message: target window unreachable (LinkedRespondableCommunicator not linked to it)",
+]
+`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -11,3 +11,5 @@ exports[`AxeFrameMessenger post/open communication logs an error if the underlyi
   "Error while attempting to send axe-core frameMessenger message: target window unreachable (LinkedRespondableCommunicator not linked to it)",
 ]
 `;
+
+exports[`AxeFrameMessenger post/open communication passes a generic Error object to the replyHandler if a topicHandler throws 1`] = `"An axe-core error occurred in a child frame."`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/axe-frame-messenger.test.ts.snap
@@ -6,6 +6,12 @@ exports[`AxeFrameMessenger post/open communication does not invoke closed topic 
 ]
 `;
 
+exports[`AxeFrameMessenger post/open communication logs an error and noops if a replyHandler throws 1`] = `
+[
+  "An axe-core error occurred while processing a result from a child frame.",
+]
+`;
+
 exports[`AxeFrameMessenger post/open communication logs an error if the underlying communicator fails 1`] = `
 [
   "Error while attempting to send axe-core frameMessenger message: target window unreachable (LinkedRespondableCommunicator not linked to it)",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
@@ -17,3 +17,5 @@ exports[`RespondableCommandMessageCommunicator promise message behavior timeout 
   "Received a response for command command1 after it timed out",
 ]
 `;
+
+exports[`RespondableCommandMessageCommunicator promise message behavior timeout behavior rejects with an error that warns about potential message interception 1`] = `"Timed out attempting to establish communication with target window. Is there a script inside it intercepting window messages? Underlying error: mock timeout"`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RespondableCommandMessageCommunicator callback message behavior handles throwing listeners by logging an error at the receiver 1`] = `
+[
+  "Error at command1 listener callback: from listener",
+]
+`;
+
 exports[`RespondableCommandMessageCommunicator promise message behavior timeout behavior logs an error if a response comes back after we already failed with a timeout 1`] = `
 [
   "Received a response for command command1 after it timed out",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RespondableCommandMessageCommunicator promise message behavior timeout behavior logs an error if a response comes back after we already failed with a timeout 1`] = `
+[
+  "Received a response for command command1 after it timed out",
+]
+`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
@@ -12,6 +12,8 @@ exports[`RespondableCommandMessageCommunicator callback message behavior handles
 ]
 `;
 
+exports[`RespondableCommandMessageCommunicator callback message behavior propagates errors from the underlying postMessage by rejecting with them as-is 1`] = `"target window unreachable (LinkedWindowMessagePoster not linked to it)"`;
+
 exports[`RespondableCommandMessageCommunicator promise message behavior timeout behavior logs an error if a response comes back after we already failed with a timeout 1`] = `
 [
   "Received a response for command command1 after it timed out",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/respondable-command-message-communicator.test.ts.snap
@@ -6,6 +6,12 @@ exports[`RespondableCommandMessageCommunicator callback message behavior handles
 ]
 `;
 
+exports[`RespondableCommandMessageCommunicator callback message behavior handles throwing replyHandlers by logging an error at the sender 1`] = `
+[
+  "Error at unique_id response callback: from replyHandler",
+]
+`;
+
 exports[`RespondableCommandMessageCommunicator promise message behavior timeout behavior logs an error if a response comes back after we already failed with a timeout 1`] = `
 [
   "Received a response for command command1 after it timed out",

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SingleFrameMessenger sendMessageToFrame/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"target window unreachable (LinkedRespondableCommunicator not linked to it)"`;
+
 exports[`SingleFrameMessenger sendMessageToWindow/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"from throw-error listener"`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`SingleFrameMessenger sendMessageToFrame/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"target window unreachable (LinkedRespondableCommunicator not linked to it)"`;
 
+exports[`SingleFrameMessenger sendMessageToFrame/addMessageListener communication rejects with a descriptive error if the target has no contentWindow 1`] = `"Target frame does not have a contentWindow"`;
+
 exports[`SingleFrameMessenger sendMessageToFrame/addMessageListener communication rejects with a descriptive error if the target's sandbox attribute disallows scripts 1`] = `"Target frame has a sandbox attribute which disallows scripts"`;
 
 exports[`SingleFrameMessenger sendMessageToWindow/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"from throw-error listener"`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
@@ -2,4 +2,6 @@
 
 exports[`SingleFrameMessenger sendMessageToFrame/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"target window unreachable (LinkedRespondableCommunicator not linked to it)"`;
 
+exports[`SingleFrameMessenger sendMessageToFrame/addMessageListener communication rejects with a descriptive error if the target's sandbox attribute disallows scripts 1`] = `"Target frame has a sandbox attribute which disallows scripts"`;
+
 exports[`SingleFrameMessenger sendMessageToWindow/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"from throw-error listener"`;

--- a/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
+++ b/src/tests/unit/tests/injected/frameCommunicators/__snapshots__/single-frame-messenger.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SingleFrameMessenger sendMessageToWindow/addMessageListener communication propagates rejection from the underlying communicator 1`] = `"from throw-error listener"`;

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -341,11 +341,7 @@ describe(AxeFrameMessenger, () => {
                 noopReplyHandler,
             );
 
-            expect(logger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "AxeFrameMessenger does not support replies-to-replies, but a topicHandler provided a replyHandler in a response callback.",
-                ]
-            `);
+            expect(logger.errorMessages).toMatchSnapshot();
             mockReplyHandler.verify(m => m(It.isAny(), It.isAny(), It.isAny()), Times.never());
             expect(postReturn).toBe(true);
         });

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -251,9 +251,7 @@ describe(AxeFrameMessenger, () => {
             mockReplyHandler
                 .setup(m => m(It.isAnyObject(Error), false, It.isAny()))
                 .callback(receivedError => {
-                    expect(receivedError.message).toMatchInlineSnapshot(
-                        `"An axe-core error occurred in a child frame."`,
-                    );
+                    expect(receivedError.message).toMatchSnapshot();
                 });
 
             childMessenger.open(topicHandler);

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -299,11 +299,7 @@ describe(AxeFrameMessenger, () => {
 
             await flushSettledPromises();
 
-            expect(logger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "Received unexpected axe-core message from a non-parent window",
-                ]
-            `);
+            expect(logger.errorMessages).toMatchSnapshot();
             mockTopicHandler.verify(m => m(It.isAny(), It.isAny()), Times.never());
             mockReplyHandler.verify(m => m(It.isAny(), It.isAny(), It.isAny()), Times.never());
             expect(postReturn).toBe(true);

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -206,11 +206,7 @@ describe(AxeFrameMessenger, () => {
 
             await flushSettledPromises();
 
-            expect(logger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "Error while attempting to send axe-core frameMessenger message: target window unreachable (LinkedRespondableCommunicator not linked to it)",
-                ]
-            `);
+            expect(logger.errorMessages).toMatchSnapshot();
             mockTopicHandler.verifyAll();
             expect(postReturn).toBe(true);
         });

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -239,11 +239,7 @@ describe(AxeFrameMessenger, () => {
 
             await flushSettledPromises();
 
-            expect(logger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "Error while attempting to send axe-core frameMessenger message: target window reachable, but is not listening for command axe.frameMessenger.post",
-                ]
-            `);
+            expect(logger.errorMessages).toMatchSnapshot();
             mockTopicHandler.verify(m => m(It.isAny(), It.isAny()), Times.never());
             expect(postReturn).toBe(true);
         });

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -323,11 +323,7 @@ describe(AxeFrameMessenger, () => {
 
             await flushSettledPromises();
 
-            expect(logger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "AxeFrameMessenger does not support replies-to-replies, but a post replyHandler invoked a responder.",
-                ]
-            `);
+            expect(logger.errorMessages).toMatchSnapshot();
             expect(postReturn).toBe(true);
         });
 

--- a/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/axe-frame-messenger.test.ts
@@ -285,11 +285,7 @@ describe(AxeFrameMessenger, () => {
 
             await flushSettledPromises();
 
-            expect(logger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "An axe-core error occurred while processing a result from a child frame.",
-                ]
-            `);
+            expect(logger.errorMessages).toMatchSnapshot();
             expect(postReturn).toBe(true);
         });
 

--- a/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
@@ -624,11 +624,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockReplyHandler.verifyAll();
             senderLogger.verifyNoErrors();
 
-            expect(receiverLogger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "Error at command1 listener callback: from listener",
-                ]
-            `);
+            expect(receiverLogger.errorMessages).toMatchSnapshot();
         });
 
         it('handles throwing replyHandlers by logging an error at the sender', async () => {

--- a/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
@@ -408,11 +408,7 @@ describe('RespondableCommandMessageCommunicator', () => {
                     targetWindow,
                 );
 
-                expect(recordingLogger.errorMessages).toMatchInlineSnapshot(`
-                    [
-                      "Received a response for command command1 after it timed out",
-                    ]
-                `);
+                expect(recordingLogger.errorMessages).toMatchSnapshot();
             });
         });
 

--- a/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
@@ -384,9 +384,7 @@ describe('RespondableCommandMessageCommunicator', () => {
                 testSubject.initialize();
                 await expect(
                     testSubject.sendPromiseCommandMessage(targetWindow, commandMessage),
-                ).rejects.toThrowErrorMatchingInlineSnapshot(
-                    `"Timed out attempting to establish communication with target window. Is there a script inside it intercepting window messages? Underlying error: mock timeout"`,
-                );
+                ).rejects.toThrowErrorMatchingSnapshot();
 
                 expect(recordingLogger.errorMessages).toStrictEqual([]);
             });

--- a/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
@@ -661,11 +661,7 @@ describe('RespondableCommandMessageCommunicator', () => {
             mockReplyHandler.verifyAll();
             receiverLogger.verifyNoErrors();
 
-            expect(senderLogger.errorMessages).toMatchInlineSnapshot(`
-                [
-                  "Error at unique_id response callback: from replyHandler",
-                ]
-            `);
+            expect(senderLogger.errorMessages).toMatchSnapshot();
         });
     });
 });

--- a/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/respondable-command-message-communicator.test.ts
@@ -591,9 +591,7 @@ describe('RespondableCommandMessageCommunicator', () => {
                     noopReplyHandler,
                     'single',
                 ),
-            ).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"target window unreachable (LinkedWindowMessagePoster not linked to it)"`,
-            );
+            ).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it('handles throwing listeners by logging an error at the receiver', async () => {

--- a/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
@@ -91,9 +91,7 @@ describe(SingleFrameMessenger, () => {
                 irrelevantMessage,
             );
 
-            await expect(sendToFrameWithoutWindow).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"Target frame does not have a contentWindow"`,
-            );
+            await expect(sendToFrameWithoutWindow).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it("resolves with the other end's response for valid frame with no sandbox attr", async () => {

--- a/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
@@ -68,9 +68,7 @@ describe(SingleFrameMessenger, () => {
                 payload: 'irrelevant',
             });
 
-            await expect(sendPromise).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"target window unreachable (LinkedRespondableCommunicator not linked to it)"`,
-            );
+            await expect(sendPromise).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it("rejects with a descriptive error if the target's sandbox attribute disallows scripts", async () => {

--- a/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
@@ -81,11 +81,7 @@ describe(SingleFrameMessenger, () => {
                 irrelevantMessage,
             );
 
-            await expect(
-                sendToFrameWithRestrictiveSandbox,
-            ).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"Target frame has a sandbox attribute which disallows scripts"`,
-            );
+            await expect(sendToFrameWithRestrictiveSandbox).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it('rejects with a descriptive error if the target has no contentWindow', async () => {

--- a/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/single-frame-messenger.test.ts
@@ -42,9 +42,7 @@ describe(SingleFrameMessenger, () => {
                 payload: 'irrelevant',
             });
 
-            await expect(sendToFailingListener).rejects.toThrowErrorMatchingInlineSnapshot(
-                `"from throw-error listener"`,
-            );
+            await expect(sendToFailingListener).rejects.toThrowErrorMatchingSnapshot();
         });
 
         it("resolves with the other end's response in the happy path", async () => {

--- a/src/tests/unit/tests/scanner/__snapshots__/axe-utils.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/axe-utils.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AxeUtils getUniqueSelector Throws if axe.setup has already been invoked (ie, a scan is in progress) 1`] = `"Axe is already setup. Call \`axe.teardown()\` before calling \`axe.setup\` again."`;

--- a/src/tests/unit/tests/scanner/__snapshots__/axe-utils.test.ts.snap
+++ b/src/tests/unit/tests/scanner/__snapshots__/axe-utils.test.ts.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AxeUtils getUniqueSelector Throws if axe.setup has already been invoked (ie, a scan is in progress) 1`] = `"Axe is already setup. Call \`axe.teardown()\` before calling \`axe.setup\` again."`;
+
+exports[`AxeUtils withAxeSetup Throws if axe.setup has already been invoked (ie, a scan is in progress) 1`] = `"Axe is already setup. Call \`axe.teardown()\` before calling \`axe.setup\` again."`;

--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -560,9 +560,7 @@ describe('AxeUtils', () => {
     describe('withAxeSetup', () => {
         it('Throws if axe.setup has already been invoked (ie, a scan is in progress)', () => {
             AxeUtils.withAxeSetup(() => {
-                expect(() => AxeUtils.withAxeSetup(() => {})).toThrowErrorMatchingInlineSnapshot(
-                    `"Axe is already setup. Call \`axe.teardown()\` before calling \`axe.setup\` again."`,
-                );
+                expect(() => AxeUtils.withAxeSetup(() => {})).toThrowErrorMatchingSnapshot();
             });
         });
 

--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -539,11 +539,7 @@ describe('AxeUtils', () => {
 
         it('Throws if axe.setup has already been invoked (ie, a scan is in progress)', () => {
             AxeUtils.withAxeSetup(() => {
-                expect(() =>
-                    AxeUtils.getUniqueSelector(fixture),
-                ).toThrowErrorMatchingInlineSnapshot(
-                    `"Axe is already setup. Call \`axe.teardown()\` before calling \`axe.setup\` again."`,
-                );
+                expect(() => AxeUtils.getUniqueSelector(fixture)).toThrowErrorMatchingSnapshot();
             });
         });
 


### PR DESCRIPTION
#### Details

Due to https://github.com/jestjs/jest/issues/14305, our inline snapshots are causing problems when using `yarn test -u`. We discussed this internally and decided that the simplest approach was to convert the inline snapshots to traditional snapshots. For most cases, this was just removing "Inline" from the method name and removing the string that provided the snapshot. A small number of test cases were checking multiple inline snapshots in the same test, so the approach there was to build an array of the things that were previously checked individually, then having a single snapshot for the test case.

I ran `yarn test -u` and `yarn format:fix` after making all of the changes, just to make sure that we're ready for future changes.

It will probably be easiest to review this one commit at a time--each of the 32 commits represents the conversion of a single test case.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
