### PR TITLE
chore: Update ClearlyDefined script to ignore GitHub actions

### DIFF
--- a/tools/clearly-defined/ValidateScript.bat
+++ b/tools/clearly-defined/ValidateScript.bat
@@ -62,6 +62,15 @@ if errorlevel 1 goto fail
 echo OK
 echo.
 
+@echo Passing case: local PR build of dependabot branch with github_actions type
+set BUILD_SOURCEBRANCH=
+set GITHUB_HEAD_REF=
+echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/github_actions/actions/checkout-1.2.3
+pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/github_actions/actions/checkout-1.2.3
+if errorlevel 1 goto fail
+echo OK
+echo.
+
 @echo Failing case: Package that does not exist in ClearlyDefined
 echo pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99
 pwsh -f ./check-clearly-defined.ps1 -PipelineType local -BranchName dependabot/nuget/src/Axe.Windows-2.99.99

--- a/tools/clearly-defined/check-clearly-defined.ps1
+++ b/tools/clearly-defined/check-clearly-defined.ps1
@@ -108,6 +108,10 @@ function IsPackageExcluded([string]$namespaceAndPackage) {
     return $exclusions -ne $null -and $exclusions.Contains($namespaceAndPackage)
 }
 
+function IsGithubActionsType([string]$namespace){
+    return $namespace -eq "github_actions"
+}
+
 function IsDockerImage([string]$provider){
     return $provider -eq "docker"
 }
@@ -133,6 +137,10 @@ function GetUri([string]$branchName){
     }
 
     $type = GetType $elements[1]
+    if (IsGithubActionsType $type) {
+        Write-Host "type is github_actions, skipping check"
+        Exit 0
+    }
     $provider = GetProvider $elements[1]
 
     if ($elements.Length -eq 3) {


### PR DESCRIPTION
#### Details

`check-clearly-defined.ps1` doesn't know about GitHub actions. Actions are devDepenencies by definition, so they can all be excluded. This adds a check to filter out dependabot branches that begin with "dependabot/github_actions/", based on the branch name used in #6978. The validation script is similarly updated.

Once this is reviewed and merged, the changes will be mirrored to the versions in the `axe-windows` and `accessibility-insights-windows` repos.

##### Motivation

Reduce friction from GitHub actions being updated.

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
