### PR TITLE
feat(oncall-vendor-transition): Increase Dependabot limit and move scheduled runs to 08:30 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,32 +4,31 @@ updates:
   directory: "/deploy/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
   commit-message:
     prefix: chore
     include: scope
+  open-pull-requests-limit: 20  # Default value of 5 has been problematic
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
   commit-message:
     prefix: chore
     include: scope
+  open-pull-requests-limit: 20  # Default value of 5 has been problematic
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -37,7 +36,7 @@ updates:
     prefix: chore
     include: scope
   versioning-strategy: increase
-  open-pull-requests-limit: 10 # Default value of 5 has been problematic
+  open-pull-requests-limit: 20  # Default value of 5 has been problematic
   ignore:
     # axe-core updates require enough extra validation
     # on false positives and breaking ai-web, so avoiding
@@ -73,5 +72,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "8:30"  # UTC
+  open-pull-requests-limit: 20  # Default value of 5 has been problematic

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   commit-message:
     prefix: chore
     include: scope
-  open-pull-requests-limit: 20  # Default value of 5 has been problematic
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
 - package-ecosystem: docker
   directory: "/"
   schedule:
@@ -23,7 +23,7 @@ updates:
   commit-message:
     prefix: chore
     include: scope
-  open-pull-requests-limit: 20  # Default value of 5 has been problematic
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -36,7 +36,7 @@ updates:
     prefix: chore
     include: scope
   versioning-strategy: increase
-  open-pull-requests-limit: 20  # Default value of 5 has been problematic
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
   ignore:
     # axe-core updates require enough extra validation
     # on false positives and breaking ai-web, so avoiding
@@ -73,4 +73,4 @@ updates:
   schedule:
     interval: daily
     time: "8:30"  # UTC
-  open-pull-requests-limit: 20  # Default value of 5 has been problematic
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/deploy/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -16,7 +16,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -28,7 +28,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   labels:
   - "category: engineering"
   - dependencies
@@ -72,5 +72,5 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "8:30"  # UTC
+    time: "08:30"  # UTC
   open-pull-requests-limit: 10  # Default value of 5 has been problematic


### PR DESCRIPTION
#### Details
* Dependabot for our repos is scheduled to run at fairly different times that are inconvenient for some geographies. This PR moves this repo's dependabot time to 08:30 UTC (14:00 IST, 01:30 PDT, 00:30 PST).
* Web-based projects have many dependencies, and a low Dependabot PR limit causes us to need to run Dependabot manually multiple times to update all dependencies. This PR increases the limit for all dependency receptacles.

##### Motivation
Part of [Feature 2083093](https://mseng.visualstudio.com/1ES/_queries/edit/2083093) (internal access required to view).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
