### PR TITLE
chore: Add PowerShell auto-formatting, update scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,5 +41,9 @@
     "editor.rulers": [100, 140],
     "typescript.tsdk": "node_modules/typescript/lib",
     "eslint.workingDirectories": [{ "pattern": "./packages/*/" }, { "directory": "./" }],
-    "stylelint.validate": ["css", "scss"]
+    "stylelint.validate": ["css", "scss"],
+    "[powershell]": {
+        "editor.defaultFormatter": "ms-vscode.powershell"
+    },
+    "powershell.codeFormatting.newLineAfterCloseBrace": false
 }

--- a/tools/clearly-defined/check-clearly-defined.ps1
+++ b/tools/clearly-defined/check-clearly-defined.ps1
@@ -67,7 +67,7 @@ function GetBranchName([string]$pipelineType, [string]$branchName) {
             "ado" {
                 $prBranchName = $Env:SYSTEM_PULLREQUEST_SOURCEBRANCH
                 if ($null -eq $prBranchName) {
-                    $trimmedBranchName = ($Env:BUILD_SOURCEBRANCH).Trim().Replace("refs/heads/","")
+                    $trimmedBranchName = ($Env:BUILD_SOURCEBRANCH).Trim().Replace("refs/heads/", "")
                 } else {
                     $trimmedBranchName = $prBranchName.Trim()
                 }
@@ -108,11 +108,11 @@ function IsPackageExcluded([string]$namespaceAndPackage) {
     return $null -ne $exclusions -and $exclusions.Contains($namespaceAndPackage)
 }
 
-function IsGithubActionsType([string]$namespace){
+function IsGithubActionsType([string]$namespace) {
     return $namespace -eq "github_actions"
 }
 
-function IsDockerImage([string]$provider){
+function IsDockerImage([string]$provider) {
     return $provider -eq "docker"
 }
 
@@ -128,11 +128,11 @@ function AdjustNamespace([string]$provider, [string]$rawNamespace) {
     return $rawNamespace
 }
 
-function IsTypesNamespace([string]$nameSpace){
+function IsTypesNamespace([string]$nameSpace) {
     return $nameSpace -eq "@types"
 }
 
-function GetUri([string]$branchName){
+function GetUri([string]$branchName) {
     $elements = $branchName.Split('/')
 
     if ($elements[0] -ne 'dependabot') {
@@ -164,7 +164,7 @@ function GetUri([string]$branchName){
     $indexOfLastDash = $fullPackage.LastIndexOf('-') + 1
     $packageName = $fullPackage.Substring(0, $indexOfLastDash - 1)
     $packageVersion = $fullPackage.Substring($indexOfLastDash)
-    if(IsDockerImage $provider){
+    if (IsDockerImage $provider) {
         Write-Host "'$packageName' is a Docker image, skipping check"
         Exit 0
     }
@@ -173,7 +173,6 @@ function GetUri([string]$branchName){
         Write-Host "Package '$namespaceAndPackage' is a known exclusion, skipping check"
         Exit 0
     }
-
 
     return "https://api.clearlydefined.io/definitions/$type/$provider/$namespace/$packageName/$packageVersion"
 }
@@ -202,12 +201,11 @@ try {
     Write-Host "Getting data from $uri"
     $response = Invoke-RestMethod -Uri $uri -Method Get -ErrorAction Stop
 
-    if(Get-Member -inputobject $response -name "files" -Membertype Properties) {
+    if (Get-Member -inputobject $response -name "files" -Membertype Properties) {
         Write-Host "ClearlyDefined has a definition for this package version."
         Exit 0
     }
-}
-catch {
+} catch {
     WriteFormattedError $pipelineType "Caught error - details below"
     $Error[0] | Format-List * -Force
     Exit 1


### PR DESCRIPTION
#### Details

When porting #7046 to other repos, I noticed some style inconsistencies that had crept into our PowerShell scripts. We already recommend the PowerShell extension for vscode. This PR enables its automatic formatting features for PowerShell scripts. I also ran the script against `./tools/get-chrome-web-store-refresh-token.ps1` and `./tools/clearly-defined/check-clearly-defined.ps1` to ensure consistent formatting. The first script was already well formatted--the second received some minor whitespace tweaks.

##### Motivation

Code consistency

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue:
- [s] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
