### PR TITLE
feat(wcag-2-2): Add "target size" test

### DIFF
--- a/src/assessments/pointer-motion/assessment.tsx
+++ b/src/assessments/pointer-motion/assessment.tsx
@@ -9,6 +9,7 @@ import { Assessment } from '../types/iassessment';
 import { MotionOperation } from './test-steps/motion-operation';
 import { PointerCancellation } from './test-steps/pointer-cancellation';
 import { PointerGestures } from './test-steps/pointer-gestures';
+import { TargetSize } from './test-steps/target-size';
 
 const { guidance } = content.pointerMotion;
 const key = 'pointerMotion';
@@ -29,5 +30,5 @@ export const PointerMotionAssessment: Assessment = AssessmentBuilder.Assisted({
     gettingStarted: gettingStarted,
     guidance,
     visualizationType: VisualizationType.PointerMotionAssessment,
-    requirements: [PointerGestures, PointerCancellation, MotionOperation],
+    requirements: [PointerGestures, PointerCancellation, MotionOperation, TargetSize],
 });

--- a/src/assessments/pointer-motion/test-steps/target-size.tsx
+++ b/src/assessments/pointer-motion/test-steps/target-size.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { link } from 'content/link';
+import * as content from 'content/test/pointer-motion/target-size';
+import * as React from 'react';
+
+import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
+import { Requirement } from '../../types/requirement';
+import { PointerMotionTestStep } from './test-steps';
+
+const description: JSX.Element = (
+    <span>
+        Touch targets must have sufficient size and spacing to be easily activated without
+        accidentally activating an adjacent target.
+    </span>
+);
+
+const howToTest: JSX.Element = (
+    <div>
+        <ol>
+            <li>
+                <p>
+                    Examine the target page to identify interactive elements which have been created
+                    by authors (non-native browser controls).
+                </p>
+            </li>
+            <li>
+                <p>
+                    Verify these elements are a minimum size of 24x24 css pixels. The following
+                    exceptions apply:
+                </p>
+                <ul>
+                    <li>
+                        <p>
+                            <em>Spacing</em>: These elements may be smaller than 24x24 css pixels so
+                            long as it is within a 24x24 css pixel target spacing circle that
+                            doesn’t overlap with other targets or their 24x24 target spacing circle.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <em>Equivalent</em>: If an alternative control is provided on the same
+                            page that successfully meets the target criteria.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <em>Inline</em>: The target is in a sentence, or its size is otherwise
+                            constrained by the line-height of non-target text.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <em>User agent control</em>: The size of the target is determined by the
+                            user agent and is not modified by the author.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <em>Essential</em>: A particular presentation of the target is essential
+                            or is legally required for the information to be conveyed.
+                        </p>
+                    </li>
+                </ul>
+            </li>
+            <ManualTestRecordYourResults isMultipleFailurePossible={true} />
+        </ol>
+    </div>
+);
+
+export const TargetSize: Requirement = {
+    key: PointerMotionTestStep.targetSize,
+    name: 'Target size',
+    description,
+    howToTest,
+    ...content,
+    isManual: true,
+    guidanceLinks: [link.WCAG_2_5_8],
+};

--- a/src/assessments/pointer-motion/test-steps/target-size.tsx
+++ b/src/assessments/pointer-motion/test-steps/target-size.tsx
@@ -3,8 +3,8 @@
 import { link } from 'content/link';
 import * as content from 'content/test/pointer-motion/target-size';
 import * as React from 'react';
-import * as Markup from '../../markup';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
+import * as Markup from '../../markup';
 import { Requirement } from '../../types/requirement';
 import { PointerMotionTestStep } from './test-steps';
 
@@ -32,33 +32,38 @@ const howToTest: JSX.Element = (
                 <ul>
                     <li>
                         <p>
-                            <Markup.Emphasis>Spacing</Markup.Emphasis>: These elements may be smaller than 24x24 css pixels so
-                            long as it is within a 24x24 css pixel target spacing circle that
-                            doesn’t overlap with other targets or their 24x24 target spacing circle.
+                            <Markup.Emphasis>Spacing</Markup.Emphasis>: These elements may be
+                            smaller than 24x24 css pixels so long as it is within a 24x24 css pixel
+                            target spacing circle that doesn’t overlap with other targets or their
+                            24x24 target spacing circle.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <Markup.Emphasis>Equivalent</Markup.Emphasis>: If an alternative control is provided on the same
-                            page that successfully meets the target criteria.
+                            <Markup.Emphasis>Equivalent</Markup.Emphasis>: If an alternative control
+                            is provided on the same page that successfully meets the target
+                            criteria.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <Markup.Emphasis>Inline</Markup.Emphasis>: The target is in a sentence, or its size is otherwise
-                            constrained by the line-height of non-target text.
+                            <Markup.Emphasis>Inline</Markup.Emphasis>: The target is in a sentence,
+                            or its size is otherwise constrained by the line-height of non-target
+                            text.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <Markup.Emphasis>User agent control</Markup.Emphasis>: The size of the target is determined by the
-                            user agent and is not modified by the author.
+                            <Markup.Emphasis>User agent control</Markup.Emphasis>: The size of the
+                            target is determined by the user agent and is not modified by the
+                            author.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <Markup.Emphasis>Essential</Markup.Emphasis>: A particular presentation of the target is essential
-                            or is legally required for the information to be conveyed.
+                            <Markup.Emphasis>Essential</Markup.Emphasis>: A particular presentation
+                            of the target is essential or is legally required for the information to
+                            be conveyed.
                         </p>
                     </li>
                 </ul>

--- a/src/assessments/pointer-motion/test-steps/target-size.tsx
+++ b/src/assessments/pointer-motion/test-steps/target-size.tsx
@@ -3,7 +3,7 @@
 import { link } from 'content/link';
 import * as content from 'content/test/pointer-motion/target-size';
 import * as React from 'react';
-
+import * as Markup from '../../markup';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
 import { Requirement } from '../../types/requirement';
 import { PointerMotionTestStep } from './test-steps';
@@ -32,32 +32,32 @@ const howToTest: JSX.Element = (
                 <ul>
                     <li>
                         <p>
-                            <em>Spacing</em>: These elements may be smaller than 24x24 css pixels so
+                            <Markup.Emphasis>Spacing</Markup.Emphasis>: These elements may be smaller than 24x24 css pixels so
                             long as it is within a 24x24 css pixel target spacing circle that
                             doesn’t overlap with other targets or their 24x24 target spacing circle.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <em>Equivalent</em>: If an alternative control is provided on the same
+                            <Markup.Emphasis>Equivalent</Markup.Emphasis>: If an alternative control is provided on the same
                             page that successfully meets the target criteria.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <em>Inline</em>: The target is in a sentence, or its size is otherwise
+                            <Markup.Emphasis>Inline</Markup.Emphasis>: The target is in a sentence, or its size is otherwise
                             constrained by the line-height of non-target text.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <em>User agent control</em>: The size of the target is determined by the
+                            <Markup.Emphasis>User agent control</Markup.Emphasis>: The size of the target is determined by the
                             user agent and is not modified by the author.
                         </p>
                     </li>
                     <li>
                         <p>
-                            <em>Essential</em>: A particular presentation of the target is essential
+                            <Markup.Emphasis>Essential</Markup.Emphasis>: A particular presentation of the target is essential
                             or is legally required for the information to be conveyed.
                         </p>
                     </li>

--- a/src/assessments/pointer-motion/test-steps/test-steps.ts
+++ b/src/assessments/pointer-motion/test-steps/test-steps.ts
@@ -4,4 +4,5 @@ export const enum PointerMotionTestStep {
     pointerGestures = 'pointer-gestures',
     pointerCancellation = 'pointer-cancellation',
     motionOperation = 'motion-operation',
+    targetSize = 'target-size',
 }

--- a/src/content/test/pointer-motion/index.ts
+++ b/src/content/test/pointer-motion/index.ts
@@ -4,10 +4,12 @@ import { guidance } from './guidance';
 import * as motionOperation from './motion-operation';
 import * as pointerCancellation from './pointer-cancellation';
 import * as pointerGestures from './pointer-gestures';
+import * as targetSize from './target-size';
 
 export const pointerMotion = {
     guidance,
     pointerCancellation,
     pointerGestures,
     motionOperation,
+    targetSize,
 };

--- a/src/content/test/pointer-motion/target-size.tsx
+++ b/src/content/test/pointer-motion/target-size.tsx
@@ -45,14 +45,13 @@ export const infoAndExamples = create(({ Markup }) => (
         <h3>Sufficient techniques</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://w3c.github.io/wcag/techniques/css/C42">
-                C42: Using min-height and min-width to ensure sufficient target spacing{' '}
+                Using min-height and min-width to ensure sufficient target spacing
             </Markup.HyperLink>
         </Markup.Links>
         <h3>Additional guidance</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://dl.acm.org/doi/10.1145/1152215.1152260">
-                Target size study for one-handed thumb use on small touchscreen devices | Proceedings of the 8th conference on
-                Human-computer interaction with mobile devices and services (acm.org)
+                Target size study for one-handed thumb use on small touchscreen devices
             </Markup.HyperLink>
         </Markup.Links>
     </>

--- a/src/content/test/pointer-motion/target-size.tsx
+++ b/src/content/test/pointer-motion/target-size.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, React } from '../../common';
+
+export const infoAndExamples = create(({ Markup }) => (
+    <>
+        <p>
+            Touch targets must have sufficient size and spacing to be easily activated without accidentally activating an adjacent target.
+        </p>
+
+        <h2>Why it matters</h2>
+        <p>
+            When touch targets are too small or too close together, it becomes difficult for users to activate them and having sufficient
+            target spacing helps all users who may have difficulty in confidently targeting or operating small controls. Users who benefit
+            include, but are not limited to people who use a mobile device where the touch screen is the primary mode of interaction, or the
+            use of mouse, stylus or touch input for people with mobility impairments such as hand tremors.
+        </p>
+
+        <h2>How to fix</h2>
+        <p>
+            All touch targets must be at least 24 by 24 CSS pixels in size, where size is computed by taking the largest unobscured area of
+            the touch target. If the size of the target is insufficient, then it must be at least 24 CSS pixels away from any other touch
+            target. All exception criteria may be used to achieve success for this test for example, providing a different control on the
+            same page that meets target size.
+        </p>
+
+        <h2>Example</h2>
+        <Markup.PassFail
+            failText={<p>Touch target unobscured size is too small and is too close to another touch target.</p>}
+            failExample={`<button id="target">+</button>
+<button style="margin-left: -10px"> Adjacent Target</button>`}
+            passText={<p>Touch target has sufficient size or spacing.</p>}
+            passExample={`<button style="font-size: 24px">Submit</button>
+<button>+</button>
+<button style="margin-left: 10px">Adjacent Target</button>`}
+        />
+
+        <h2>More examples</h2>
+        <h3>WCAG success criteria</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://w3c.github.io/wcag/understanding/target-size-minimum.html">
+                Understanding Success Criterion 2.5.8: Target Size (Minimum)
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Sufficient techniques</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://w3c.github.io/wcag/techniques/css/C42">
+                C42: Using min-height and min-width to ensure sufficient target spacing{' '}
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Additional guidance</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://dl.acm.org/doi/10.1145/1152215.1152260">
+                Target size study for one-handed thumb use on small touchscreen devices | Proceedings of the 8th conference on
+                Human-computer interaction with mobile devices and services (acm.org)
+            </Markup.HyperLink>
+        </Markup.Links>
+    </>
+));

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -26970,7 +26970,7 @@ exports[`Guidance Content pages test/pointerMotion/targetSize/infoAndExamples ma
           href="https://w3c.github.io/wcag/techniques/css/C42"
           target="_blank"
         >
-          C42: Using min-height and min-width to ensure sufficient target spacing 
+          Using min-height and min-width to ensure sufficient target spacing
         </a>
       </div>
       <h3>
@@ -26984,7 +26984,7 @@ exports[`Guidance Content pages test/pointerMotion/targetSize/infoAndExamples ma
           href="https://dl.acm.org/doi/10.1145/1152215.1152260"
           target="_blank"
         >
-          Target size study for one-handed thumb use on small touchscreen devices | Proceedings of the 8th conference on Human-computer interaction with mobile devices and services (acm.org)
+          Target size study for one-handed thumb use on small touchscreen devices
         </a>
       </div>
     </div>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -26789,6 +26789,212 @@ exports[`Guidance Content pages test/pointerMotion/pointerGestures/infoAndExampl
 </DocumentFragment>
 `;
 
+exports[`Guidance Content pages test/pointerMotion/targetSize/infoAndExamples matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <p>
+        Touch targets must have sufficient size and spacing to be easily activated without accidentally activating an adjacent target.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        When touch targets are too small or too close together, it becomes difficult for users to activate them and having sufficient target spacing helps all users who may have difficulty in confidently targeting or operating small controls. Users who benefit include, but are not limited to people who use a mobile device where the touch screen is the primary mode of interaction, or the use of mouse, stylus or touch input for people with mobility impairments such as hand tremors.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        All touch targets must be at least 24 by 24 CSS pixels in size, where size is computed by taking the largest unobscured area of the touch target. If the size of the target is insufficient, then it must be at least 24 CSS pixels away from any other touch target. All exception criteria may be used to achieve success for this test for example, providing a different control on the same page that meets target size.
+      </p>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="var(--neutral-0)"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            Touch target unobscured size is too small and is too close to another touch target.
+          </p>
+        </div>
+        <div
+          class="fail-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;button id="target"&gt;+&lt;/button&gt;
+                <br />
+                &lt;button style="margin-left: -10px"&gt; Adjacent Target&lt;/button&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="var(--neutral-0)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            Touch target has sufficient size or spacing.
+          </p>
+        </div>
+        <div
+          class="pass-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;button style="font-size: 24px"&gt;Submit&lt;/button&gt;
+                <br />
+                &lt;button&gt;+&lt;/button&gt;
+                <br />
+                &lt;button style="margin-left: 10px"&gt;Adjacent Target&lt;/button&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://w3c.github.io/wcag/understanding/target-size-minimum.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 2.5.8: Target Size (Minimum)
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://w3c.github.io/wcag/techniques/css/C42"
+          target="_blank"
+        >
+          C42: Using min-height and min-width to ensure sufficient target spacing 
+        </a>
+      </div>
+      <h3>
+        Additional guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://dl.acm.org/doi/10.1145/1152215.1152260"
+          target="_blank"
+        >
+          Target size study for one-handed thumb use on small touchscreen devices | Proceedings of the 8th conference on Human-computer interaction with mobile devices and services (acm.org)
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Guidance Content pages test/repetitiveContent/bypassBlocks matches the snapshot 1`] = `
 <DocumentFragment>
   <div


### PR DESCRIPTION
#### Details
This PR adds "target size" from WCAG 2.2 to the "pointer motion" assessment.

##### Motivation
Part of the WCAG 2.2 feature (accessible internally on Azure DevOps).

##### Context
This will probably conflict with #7058, I'll rebase whichever goes in second and fix any resulting conflicts.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
