### PR TITLE
feat(wcag-2-2): Add Cognitive Assessment and Requirements

### DIFF
--- a/src/assessments/assessments.ts
+++ b/src/assessments/assessments.ts
@@ -4,6 +4,7 @@ import { AdaptableContentAssessment } from './adaptable-content/assessment';
 import { AssessmentsProviderImpl } from './assessments-provider';
 import { AudioVideoOnlyAssessment } from './audio-video-only/assessment';
 import { AutomatedChecks } from './automated-checks/assessment';
+import { CognitiveAssessment } from './cognitive/assessment';
 import { ColorSensoryAssessment } from './color/assessment';
 import { ContrastAssessment } from './contrast/assessment';
 import { CustomWidgets } from './custom-widgets/assessment';
@@ -52,4 +53,5 @@ export const Assessments: AssessmentsProvider = AssessmentsProviderImpl.Create([
     SemanticsAssessment,
     PointerMotionAssessment,
     ContrastAssessment,
+    CognitiveAssessment,
 ]);

--- a/src/assessments/cognitive/assessment.tsx
+++ b/src/assessments/cognitive/assessment.tsx
@@ -3,10 +3,13 @@
 
 import { RedundantEntry } from 'assessments/cognitive/test-steps/redundant-entry';
 import { VisualizationType } from 'common/types/visualization-type';
+import { test as content } from 'content/test';
 import * as React from 'react';
 import { AssessmentBuilder } from '../assessment-builder';
 import { Assessment } from '../types/iassessment';
 import { Authentication } from './test-steps/authentication';
+
+const { guidance } = content.pointerMotion;
 
 const key = 'cognitive';
 const title = 'Cognitive';
@@ -22,6 +25,7 @@ export const CognitiveAssessment: Assessment = AssessmentBuilder.Manual({
     key,
     title,
     gettingStarted,
+    guidance,
     requirements: [RedundantEntry, Authentication],
     isEnabled: true,
 });

--- a/src/assessments/cognitive/assessment.tsx
+++ b/src/assessments/cognitive/assessment.tsx
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { RedundantEntry } from 'assessments/cognitive/test-steps/redundant-entry';
 import { VisualizationType } from 'common/types/visualization-type';
 import * as React from 'react';
 import { AssessmentBuilder } from '../assessment-builder';
 import { Assessment } from '../types/iassessment';
 import { Authentication } from './test-steps/authentication';
-import { RedundantEntry } from 'assessments/cognitive/test-steps/redundant-entry';
 
-const key = 'keyboardInteraction';
+const key = 'cognitive';
 const title = 'Cognitive';
 
 const gettingStarted: JSX.Element = (
@@ -17,8 +17,8 @@ const gettingStarted: JSX.Element = (
     </React.Fragment>
 );
 
-export const Cognitive: Assessment = AssessmentBuilder.Manual({
-    visualizationType: VisualizationType.ParsingAssessment,
+export const CognitiveAssessment: Assessment = AssessmentBuilder.Manual({
+    visualizationType: VisualizationType.CognitiveAssessment,
     key,
     title,
     gettingStarted,

--- a/src/assessments/cognitive/assessment.tsx
+++ b/src/assessments/cognitive/assessment.tsx
@@ -17,11 +17,11 @@ const title = 'Cognitive';
 const gettingStarted: JSX.Element = (
     <React.Fragment>
         <p>
-            When interfaces require repetitive entry of user data, or necessitate that users recall
+            When interfaces require repetitive entry of user data or necessitate that users recall
             information, solve problems or transcribe information to login, it can unnecessarily
             increase the cognitive load a user must handle. For people with cognitive and/or
             learning disabilities, increasing cognitive load in these ways can lead to unnecessary
-            errors with data entry, or create barriers to login to websites or applications.
+            errors with data entry or create barriers to login to websites or applications.
         </p>
     </React.Fragment>
 );

--- a/src/assessments/cognitive/assessment.tsx
+++ b/src/assessments/cognitive/assessment.tsx
@@ -9,14 +9,20 @@ import { AssessmentBuilder } from '../assessment-builder';
 import { Assessment } from '../types/iassessment';
 import { Authentication } from './test-steps/authentication';
 
-const { guidance } = content.pointerMotion;
+const { guidance } = content.cognitive;
 
 const key = 'cognitive';
 const title = 'Cognitive';
 
 const gettingStarted: JSX.Element = (
     <React.Fragment>
-        <p>Placeholder for Cognitive Assessment Getting Started.</p>
+        <p>
+            When interfaces require repetitive entry of user data, or necessitate that users recall
+            information, solve problems or transcribe information to login, it can unnecessarily
+            increase the cognitive load a user must handle. For people with cognitive and/or
+            learning disabilities, increasing cognitive load in these ways can lead to unnecessary
+            errors with data entry, or create barriers to login to websites or applications.
+        </p>
     </React.Fragment>
 );
 

--- a/src/assessments/cognitive/assessment.tsx
+++ b/src/assessments/cognitive/assessment.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { VisualizationType } from 'common/types/visualization-type';
+import * as React from 'react';
+import { AssessmentBuilder } from '../assessment-builder';
+import { Assessment } from '../types/iassessment';
+import { Authentication } from './test-steps/authentication';
+import { RedundantEntry } from 'assessments/cognitive/test-steps/redundant-entry';
+
+const key = 'keyboardInteraction';
+const title = 'Cognitive';
+
+const gettingStarted: JSX.Element = (
+    <React.Fragment>
+        <p>Placeholder for Cognitive Assessment Getting Started.</p>
+    </React.Fragment>
+);
+
+export const Cognitive: Assessment = AssessmentBuilder.Manual({
+    visualizationType: VisualizationType.ParsingAssessment,
+    key,
+    title,
+    gettingStarted,
+    requirements: [RedundantEntry, Authentication],
+    isEnabled: true,
+});

--- a/src/assessments/cognitive/test-steps/authentication.tsx
+++ b/src/assessments/cognitive/test-steps/authentication.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { link } from 'content/link';
+import * as content from 'content/test/cognitive/authentication';
+import * as React from 'react';
+import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
+import { Requirement } from '../../types/requirement';
+import { CognitiveTestStep } from './test-steps';
+
+const description: JSX.Element = (
+    <span>
+        People with cognitive issues relating to memory, reading (for example, dyslexia), numbers
+        (for example, dyscalculia), or perception-processing limitations will be able to
+        authenticate irrespective of the level of their cognitive abilities.
+    </span>
+);
+
+const howToTest: JSX.Element = (
+    <div>
+        <p>
+            Note: Text-based personal content does not qualify for an exception as it relies on
+            recall (rather than recognition), and transcription (rather than selecting an item).
+        </p>
+        <ol>
+            <li>
+                Examine the target page to identify structure of input fields and verify whether
+                they prevent the user from pasting or auto-filling the entire password or code in
+                the format in which it was originally created.
+            </li>
+            <li>
+                Confirm whether any other acceptable authentication methods are present that satisfy
+                the criteria such as an authentication method that does not rely on a cognitive
+                function test.
+            </li>
+            <li>If either of these above conditions fail, the test is considered a failure.</li>
+            <ManualTestRecordYourResults isMultipleFailurePossible={true} />
+        </ol>
+    </div>
+);
+
+export const Authentication: Requirement = {
+    key: CognitiveTestStep.authentication,
+    name: 'Accessible Authentication (Minimum)',
+    description,
+    howToTest,
+    isManual: true,
+    ...content,
+    guidanceLinks: [link.WCAG_3_3_8],
+};

--- a/src/assessments/cognitive/test-steps/authentication.tsx
+++ b/src/assessments/cognitive/test-steps/authentication.tsx
@@ -40,7 +40,7 @@ const howToTest: JSX.Element = (
 
 export const Authentication: Requirement = {
     key: CognitiveTestStep.authentication,
-    name: 'Accessible Authentication (Minimum)',
+    name: 'Authentication',
     description,
     howToTest,
     isManual: true,

--- a/src/assessments/cognitive/test-steps/authentication.tsx
+++ b/src/assessments/cognitive/test-steps/authentication.tsx
@@ -23,9 +23,9 @@ const howToTest: JSX.Element = (
         </p>
         <ol>
             <li>
-                Examine the target page to identify structure of input fields and verify whether
-                they prevent the user from pasting or auto-filling the entire password or code in
-                the format in which it was originally created.
+                Examine the target page to identify the input fields and verify whether they prevent
+                the user from pasting or auto-filling the entire password or code in the format in
+                which it was originally created.
             </li>
             <li>
                 Confirm whether any other acceptable authentication methods are present that satisfy

--- a/src/assessments/cognitive/test-steps/redundant-entry.tsx
+++ b/src/assessments/cognitive/test-steps/redundant-entry.tsx
@@ -9,7 +9,7 @@ import { CognitiveTestStep } from './test-steps';
 
 const description: JSX.Element = (
     <span>
-        Do not require people to re-enter information they have already provided via other means –
+        Do not require people to re-enter information they have already provided via other means -
         e.g., as part of a previous step in the same form.
     </span>
 );

--- a/src/assessments/cognitive/test-steps/redundant-entry.tsx
+++ b/src/assessments/cognitive/test-steps/redundant-entry.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { link } from 'content/link';
+import * as content from 'content/test/cognitive/redundant-entry';
+import * as React from 'react';
+import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
+import { Requirement } from '../../types/requirement';
+import { CognitiveTestStep } from './test-steps';
+
+const description: JSX.Element = (
+    <span>
+        Do not require people to re-enter information they have already provided via other means –
+        e.g., as part of a previous step in the same form.
+    </span>
+);
+
+const howToTest: JSX.Element = (
+    <div>
+        <p>Note: this criterion does not require help to be provided.</p>
+        <ol>
+            <li>
+                Examine the target page to identify user input mechanisms that request information
+                to be entered (for example form fields, passwords, etc.)
+            </li>
+            <li>
+                Verify if the information has already been requested on a previous step of the
+                process and that the information entered previously is prepopulated in the fields or
+                displayed on the page. If either of these conditions fail, the test is considered a
+                failure.
+            </li>
+            <ManualTestRecordYourResults isMultipleFailurePossible={true} />
+        </ol>
+    </div>
+);
+
+export const RedundantEntry: Requirement = {
+    key: CognitiveTestStep.authentication,
+    name: 'Accessible Authentication (Minimum)',
+    description,
+    howToTest,
+    isManual: true,
+    ...content,
+    guidanceLinks: [link.WCAG_3_3_7],
+};

--- a/src/assessments/cognitive/test-steps/redundant-entry.tsx
+++ b/src/assessments/cognitive/test-steps/redundant-entry.tsx
@@ -9,7 +9,7 @@ import { CognitiveTestStep } from './test-steps';
 
 const description: JSX.Element = (
     <span>
-        Do not require people to re-enter information they have already provided via other means -
+        Do not require people to re-enter information they have already provided via other means&nbsp;– 
         e.g., as part of a previous step in the same form.
     </span>
 );

--- a/src/assessments/cognitive/test-steps/redundant-entry.tsx
+++ b/src/assessments/cognitive/test-steps/redundant-entry.tsx
@@ -16,7 +16,6 @@ const description: JSX.Element = (
 
 const howToTest: JSX.Element = (
     <div>
-        <p>Note: this criterion does not require help to be provided.</p>
         <ol>
             <li>
                 Examine the target page to identify user input mechanisms that request information

--- a/src/assessments/cognitive/test-steps/redundant-entry.tsx
+++ b/src/assessments/cognitive/test-steps/redundant-entry.tsx
@@ -34,8 +34,8 @@ const howToTest: JSX.Element = (
 );
 
 export const RedundantEntry: Requirement = {
-    key: CognitiveTestStep.authentication,
-    name: 'Accessible Authentication (Minimum)',
+    key: CognitiveTestStep.redundantEntry,
+    name: 'Redundant Entry',
     description,
     howToTest,
     isManual: true,

--- a/src/assessments/cognitive/test-steps/redundant-entry.tsx
+++ b/src/assessments/cognitive/test-steps/redundant-entry.tsx
@@ -9,8 +9,8 @@ import { CognitiveTestStep } from './test-steps';
 
 const description: JSX.Element = (
     <span>
-        Do not require people to re-enter information they have already provided via other means&nbsp;– 
-        e.g., as part of a previous step in the same form.
+        Do not require people to re-enter information they have already provided via other
+        means&nbsp;– e.g., as part of a previous step in the same form.
     </span>
 );
 
@@ -34,7 +34,7 @@ const howToTest: JSX.Element = (
 
 export const RedundantEntry: Requirement = {
     key: CognitiveTestStep.redundantEntry,
-    name: 'Redundant Entry',
+    name: 'Redundant entry',
     description,
     howToTest,
     isManual: true,

--- a/src/assessments/cognitive/test-steps/test-steps.ts
+++ b/src/assessments/cognitive/test-steps/test-steps.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const enum CognitiveTestStep {
+    authentication = 'authentication',
+    redundantEntry = 'redundant-entry',
+}

--- a/src/common/types/visualization-type.ts
+++ b/src/common/types/visualization-type.ts
@@ -42,4 +42,5 @@ export enum VisualizationType {
     AutomatedChecksQuickAssess,
     ContrastQuickAssess,
     NativeWidgetsQuickAssess,
+    CognitiveAssessment,
 }

--- a/src/content/test/cognitive/authentication.tsx
+++ b/src/content/test/cognitive/authentication.tsx
@@ -10,7 +10,7 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         </p>
         <h2>Why it matters</h2>
         <p>
-            This is value for people with certain cognitive disabilities to ensure that there is an accessible, easy-to-use, and secure
+            This is valuable for people with certain cognitive disabilities to ensure that there is an accessible, easy-to-use, and secure
             method to log in. Most Web sites rely on usernames and passwords for logging in. Memorizing or transcribing a username,
             password, or one-time verification code places a very high or impossible burden upon people with certain cognitive disabilities.
         </p>

--- a/src/content/test/cognitive/authentication.tsx
+++ b/src/content/test/cognitive/authentication.tsx
@@ -27,10 +27,13 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <h2>Example</h2>
         <Markup.PassFail
             failText={
-                <p>
-                    A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields
-                    for each character.{' '}
-                </p>
+                <>
+                    <p>
+                        A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input
+                        fields for each character.
+                    </p>
+                    <p>See more failure examples below.</p>
+                </>
             }
             failExample={
                 <p>The block paste functionality for the website is blocked and user is unable to copy credentials into the login form.</p>
@@ -53,7 +56,7 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <h3>WCAG success criteria</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">
-                Understanding Success Criterion 3.3.8: Accessible Authentication (Minimum)
+                Understanding Success Criterion 3.3.8: Accessible Authentication
             </Markup.HyperLink>
         </Markup.Links>
         <h3>Sufficient techniques</h3>
@@ -68,8 +71,11 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
                 Cognitive Accessibility Roadmap and Gap Analysis
             </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern">
+            <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/">
                 Making Content Usable for People with Cognitive and Learning Disabilities
+            </Markup.HyperLink>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/failures/F109">
+                Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format
             </Markup.HyperLink>
         </Markup.Links>
     </>

--- a/src/content/test/cognitive/authentication.tsx
+++ b/src/content/test/cognitive/authentication.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, React } from '../../common';
+
+export const infoAndExamples = create(({ Markup, Link }) => (
+    <>
+        <p>
+            People with cognitive issues relating to memory, reading (for example, dyslexia), numbers (for example, dyscalculia), or
+            perception-processing limitations will be able to authenticate irrespective of the level of their cognitive abilities.
+        </p>
+        <h2>Why it matters</h2>
+        <p>
+            This is value for people with certain cognitive disabilities to ensure that there is an accessible, easy-to-use, and secure
+            method to log in. Most Web sites rely on usernames and passwords for logging in. Memorizing or transcribing a username,
+            password, or one-time verification code places a very high or impossible burden upon people with certain cognitive disabilities.
+        </p>
+
+        <h2>How to fix</h2>
+        <p>
+            Ensure that login functionalities in the system don’t make people solve, recall, or transcribe something to log in. Consider
+            using the following techniques to make authentication more accessible such as:
+        </p>
+        <ul>
+            <li>Copy & paste functionality is enabled.</li>
+            <li>2-factor authentication systems with verification codes to prevent higher cognitive recall.</li>
+        </ul>
+        <h2>Example</h2>
+        <Markup.PassFail
+            failText={
+                <p>
+                    A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields
+                    for each character.{' '}
+                </p>
+            }
+            failExample={
+                <p>The block paste functionality for the website is blocked and user is unable to copy credentials into the login form.</p>
+            }
+            passText={
+                <p>
+                    A social media website has a username and password based login mechanism. As part of the forgotten password feature,
+                    there is a separate link to login with an email. When the user enters their email and submits the form, the site sends
+                    an email to the user. Clicking the link in the email opens the website and the user is logged in.
+                </p>
+            }
+            passExample={
+                <p>
+                    A web site does not block paste functionality. The user is able to use a third-party password manager to store
+                    credentials, copy them, and paste them directly into a login form.
+                </p>
+            }
+        />
+        <h2>More examples</h2>
+        <h3>WCAG success criteria</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">
+                Understanding Success Criterion 3.3.8: Accessible Authentication (Minimum) | WAI | W3C
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Sufficient techniques</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/html/H100">
+                H100: Providing properly marked up email and password inputs | WAI | W3C
+            </Markup.HyperLink>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218">
+                G218: Email link authentication | WAI | W3C
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Additional Guidance</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
+                Cognitive Accessibility Roadmap and Gap Analysis (w3.org)
+            </Markup.HyperLink>
+            <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern">
+                Making Content Usable for People with Cognitive and Learning Disabilities (w3.org)
+            </Markup.HyperLink>
+        </Markup.Links>
+    </>
+));

--- a/src/content/test/cognitive/authentication.tsx
+++ b/src/content/test/cognitive/authentication.tsx
@@ -53,25 +53,23 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <h3>WCAG success criteria</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">
-                Understanding Success Criterion 3.3.8: Accessible Authentication (Minimum) | WAI | W3C
+                Understanding Success Criterion 3.3.8: Accessible Authentication (Minimum)
             </Markup.HyperLink>
         </Markup.Links>
         <h3>Sufficient techniques</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/html/H100">
-                H100: Providing properly marked up email and password inputs | WAI | W3C
+                Providing properly marked up email and password inputs
             </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218">
-                G218: Email link authentication | WAI | W3C
-            </Markup.HyperLink>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218">Email link authentication</Markup.HyperLink>
         </Markup.Links>
         <h3>Additional Guidance</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
-                Cognitive Accessibility Roadmap and Gap Analysis (w3.org)
+                Cognitive Accessibility Roadmap and Gap Analysis
             </Markup.HyperLink>
             <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern">
-                Making Content Usable for People with Cognitive and Learning Disabilities (w3.org)
+                Making Content Usable for People with Cognitive and Learning Disabilities
             </Markup.HyperLink>
         </Markup.Links>
     </>

--- a/src/content/test/cognitive/authentication.tsx
+++ b/src/content/test/cognitive/authentication.tsx
@@ -17,7 +17,7 @@ export const infoAndExamples = create(({ Markup, Link }) => (
 
         <h2>How to fix</h2>
         <p>
-            Ensure that login functionalities in the system don’t make people solve, recall, or transcribe something to log in. Consider
+            Ensure that login functionalities in the system don't make people solve, recall, or transcribe something to log in. Consider
             using the following techniques to make authentication more accessible such as:
         </p>
         <ul>

--- a/src/content/test/cognitive/guidance.tsx
+++ b/src/content/test/cognitive/guidance.tsx
@@ -10,7 +10,7 @@ export const guidance = create(({ Markup, Link }) => (
             Cognitive and learning disabilities include long-term, short-term, and permanent difficulties relating to cognitive functions,
             such as:
             <ul>
-                <li>learning, communication, reading, writing, or math,</li>
+                <li>learning, communication, reading, writing, or mathematics,</li>
                 <li>
                     ability to understand or process new or complex information and learn new skills, with a reduced ability to cope
                     independently, and/or

--- a/src/content/test/cognitive/guidance.tsx
+++ b/src/content/test/cognitive/guidance.tsx
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, GuidanceTitle, React } from '../../common';
+
+export const guidance = create(({ Markup, Link }) => (
+    <>
+        <GuidanceTitle name={'Cognitive'} />
+
+        <h2>Why it matters</h2>
+
+        <p>Placeholder</p>
+
+        <Markup.Columns>
+            <Markup.Do>
+                <h3>
+                    Provide users functionality to Copy & paste passwords for authentication. (<Link.WCAG_3_3_8 />)
+                </h3>
+
+                <h3>
+                    Create systems with 2-factor authentication systems with verification codes to prevent higher cognitive recall. (
+                    <Link.WCAG_3_3_8 />)
+                </h3>
+            </Markup.Do>
+
+            <Markup.Dont>
+                <h3>
+                    Don’t rely on users memorizing or transcribing a username, password, or one-time verification code. (<Link.WCAG_3_3_8 />
+                    )
+                </h3>
+
+                <h3>
+                    Don’t require people to re-enter information they have already provided via other means. (<Link.WCAG_3_3_7 />)
+                </h3>
+                <ul>
+                    <li>Ensure processes do not rely on memory.</li>
+                    <li>
+                        Memory barriers stop people with cognitive disabilities from using content. This includes long passwords to log in
+                        and voice menus that involve remembering a specific number or term. Make sure there is an easier option for people
+                        who need it.
+                    </li>
+                </ul>
+
+                <h3>
+                    Don't use <Markup.Code>display:none</Markup.Code>, <Markup.Code>visibility:hidden</Markup.Code> or{' '}
+                    <Markup.Code>aria-hidden</Markup.Code> to make headings invisible <Markup.Emphasis>only</Markup.Emphasis> to sighted
+                    users. (a11y tech tip)
+                </h3>
+                <ul>
+                    <li>
+                        Those properties make headings unavailable to everyone, including assistive technology users. Use this CSS instead:{' '}
+                        <Markup.Code>className="element-invisible"</Markup.Code>
+                    </li>
+                </ul>
+            </Markup.Dont>
+        </Markup.Columns>
+
+        <h2>Learn more</h2>
+
+        <h3>Reduce Redundant Entry</h3>
+
+        <h4>WCAG success Criteria</h4>
+        <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html#:~:text=Redundant%20Entry%20is%20asking%20for%20the%20website%20content,essential%20purposes%20such%20as%20asking%20for%20a%20password.">
+            Understanding Success Criterion 3.3.7: Redundant Entry
+        </Markup.HyperLink>
+
+        <h4>Sufficient techniques</h4>
+        <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G221">
+            Provide data from a previous step in a process
+        </Markup.HyperLink>
+
+        <h4>Additional guidance</h4>
+        <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
+            Cognitive Accessibility Roadmap and Gap Analysis
+        </Markup.HyperLink>
+        <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/">
+            Making Content Usable for People with Cognitive and Learning Disabilities
+        </Markup.HyperLink>
+
+        <h3>Provide accessible authentication</h3>
+
+        <h4>WCAG success Criteria</h4>
+        <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">
+            Understanding Success Criterion 3.3.8: Accessible Authentication
+        </Markup.HyperLink>
+
+        <h4>Sufficient techniques</h4>
+        <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/html/H100">
+            Providing properly marked up email and password inputs
+        </Markup.HyperLink>
+        <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218">Email link authentication</Markup.HyperLink>
+
+        <h4>Additional guidance and common failures</h4>
+        <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
+            Cognitive Accessibility Roadmap and Gap Analysis
+        </Markup.HyperLink>
+        <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern">
+            Making Content Usable for People with Cognitive and Learning Disabilities
+        </Markup.HyperLink>
+        <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/failures/F109">
+            Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format
+        </Markup.HyperLink>
+    </>
+));

--- a/src/content/test/cognitive/guidance.tsx
+++ b/src/content/test/cognitive/guidance.tsx
@@ -59,18 +59,6 @@ export const guidance = create(({ Markup, Link }) => (
                         who need it.
                     </li>
                 </ul>
-
-                <h3>
-                    Don't use <Markup.Code>display:none</Markup.Code>, <Markup.Code>visibility:hidden</Markup.Code> or{' '}
-                    <Markup.Code>aria-hidden</Markup.Code> to make headings invisible <Markup.Emphasis>only</Markup.Emphasis> to sighted
-                    users. (a11y tech tip)
-                </h3>
-                <ul>
-                    <li>
-                        Those properties make headings unavailable to everyone, including assistive technology users. Use this CSS instead:{' '}
-                        <Markup.Code>className="element-invisible"</Markup.Code>
-                    </li>
-                </ul>
             </Markup.Dont>
         </Markup.Columns>
         <h2>Learn more</h2>

--- a/src/content/test/cognitive/guidance.tsx
+++ b/src/content/test/cognitive/guidance.tsx
@@ -37,7 +37,7 @@ export const guidance = create(({ Markup, Link }) => (
                 </h3>
 
                 <h3>
-                    Create systems with 2-factor authentication systems with verification codes to prevent higher cognitive recall. (
+                    Create systems with 2-factor authentication with verification codes to prevent higher cognitive recall. (
                     <Link.WCAG_3_3_8 />)
                 </h3>
             </Markup.Do>

--- a/src/content/test/cognitive/guidance.tsx
+++ b/src/content/test/cognitive/guidance.tsx
@@ -5,11 +5,31 @@ import { create, GuidanceTitle, React } from '../../common';
 export const guidance = create(({ Markup, Link }) => (
     <>
         <GuidanceTitle name={'Cognitive'} />
-
         <h2>Why it matters</h2>
-
-        <p>Placeholder</p>
-
+        <React.Fragment>
+            Cognitive and learning disabilities include long-term, short-term, and permanent difficulties relating to cognitive functions,
+            such as:
+            <ul>
+                <li>learning, communication, reading, writing, or math,</li>
+                <li>
+                    ability to understand or process new or complex information and learn new skills, with a reduced ability to cope
+                    independently, and/or
+                </li>
+                <li>memory and attention or visual, language, or numerical thinking.</li>
+            </ul>
+        </React.Fragment>
+        <p>
+            Web page design & structure can make content inaccessible to people with cognitive and learning disabilities. For example,
+            people with impaired short-term memory may be unable to recall passwords, remember access codes, or have trouble remembering
+            unfamiliar iconography. Additionally, people with cognitive and learning disabilities may need more support or time to complete
+            a new process or an authentication task.
+        </p>
+        <p>
+            It is important designs are created while considering the cognitive load they require of their users, as many people may
+            struggle with cognitive fatigue when completing complex, multi-stage processes. For instance, tasks like filling out forms while
+            entering important or sensitive data correctly or just trying to locate the content or feature that they need. Designs need to
+            consistently provide support to help minimize errors and complete their task.
+        </p>
         <Markup.Columns>
             <Markup.Do>
                 <h3>
@@ -24,12 +44,12 @@ export const guidance = create(({ Markup, Link }) => (
 
             <Markup.Dont>
                 <h3>
-                    Don’t rely on users memorizing or transcribing a username, password, or one-time verification code. (<Link.WCAG_3_3_8 />
+                    Don't rely on users memorizing or transcribing a username, password, or one-time verification code. (<Link.WCAG_3_3_8 />
                     )
                 </h3>
 
                 <h3>
-                    Don’t require people to re-enter information they have already provided via other means. (<Link.WCAG_3_3_7 />)
+                    Don't require people to re-enter information they have already provided via other means. (<Link.WCAG_3_3_7 />)
                 </h3>
                 <ul>
                     <li>Ensure processes do not rely on memory.</li>
@@ -53,21 +73,16 @@ export const guidance = create(({ Markup, Link }) => (
                 </ul>
             </Markup.Dont>
         </Markup.Columns>
-
         <h2>Learn more</h2>
-
         <h3>Reduce Redundant Entry</h3>
-
         <h4>WCAG success Criteria</h4>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html#:~:text=Redundant%20Entry%20is%20asking%20for%20the%20website%20content,essential%20purposes%20such%20as%20asking%20for%20a%20password.">
             Understanding Success Criterion 3.3.7: Redundant Entry
         </Markup.HyperLink>
-
         <h4>Sufficient techniques</h4>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G221">
             Provide data from a previous step in a process
         </Markup.HyperLink>
-
         <h4>Additional guidance</h4>
         <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
             Cognitive Accessibility Roadmap and Gap Analysis
@@ -75,20 +90,16 @@ export const guidance = create(({ Markup, Link }) => (
         <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/">
             Making Content Usable for People with Cognitive and Learning Disabilities
         </Markup.HyperLink>
-
         <h3>Provide accessible authentication</h3>
-
         <h4>WCAG success Criteria</h4>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html">
             Understanding Success Criterion 3.3.8: Accessible Authentication
         </Markup.HyperLink>
-
         <h4>Sufficient techniques</h4>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/html/H100">
             Providing properly marked up email and password inputs
         </Markup.HyperLink>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218">Email link authentication</Markup.HyperLink>
-
         <h4>Additional guidance and common failures</h4>
         <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
             Cognitive Accessibility Roadmap and Gap Analysis

--- a/src/content/test/cognitive/index.ts
+++ b/src/content/test/cognitive/index.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as authentication from './authentication';
+import { guidance } from './guidance';
 import * as redundantEntry from './redundant-entry';
 
 export const cognitive = {
     authentication,
     redundantEntry,
+    guidance,
 };

--- a/src/content/test/cognitive/index.ts
+++ b/src/content/test/cognitive/index.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as authentication from './authentication';
+import * as redundantEntry from './redundant-entry';
+
+export const cognitive = {
+    authentication,
+    redundantEntry,
+};

--- a/src/content/test/cognitive/redundant-entry.tsx
+++ b/src/content/test/cognitive/redundant-entry.tsx
@@ -5,7 +5,7 @@ import { create, React } from '../../common';
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
         <p>
-            Do not require people to re-enter information they have already provided via other means – e.g., as part of a previous step in
+            Do not require people to re-enter information they have already provided via other means - e.g., as part of a previous step in
             the same form.
         </p>
         <h2>Why it matters</h2>

--- a/src/content/test/cognitive/redundant-entry.tsx
+++ b/src/content/test/cognitive/redundant-entry.tsx
@@ -43,22 +43,22 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <h3>WCAG success criteria</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html#:~:text=Redundant%20Entry%20is%20asking%20for%20the%20website%20content,essential%20purposes%20such%20as%20asking%20for%20a%20password.">
-                Understanding Success Criterion 3.3.7: Redundant Entry | WAI | W3C
+                Understanding Success Criterion 3.3.7: Redundant Entry
             </Markup.HyperLink>
         </Markup.Links>
         <h3>Sufficient techniques</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G221">
-                G221: Provide data from a previous step in a process | WAI | W3C
+                Provide data from a previous step in a process
             </Markup.HyperLink>
         </Markup.Links>
         <h3>Additional Guidance</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
-                Cognitive Accessibility Roadmap and Gap Analysis (w3.org)
+                Cognitive Accessibility Roadmap and Gap Analysis
             </Markup.HyperLink>
             <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern">
-                Making Content Usable for People with Cognitive and Learning Disabilities (w3.org)
+                Making Content Usable for People with Cognitive and Learning Disabilities
             </Markup.HyperLink>
         </Markup.Links>
     </>

--- a/src/content/test/cognitive/redundant-entry.tsx
+++ b/src/content/test/cognitive/redundant-entry.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, React } from '../../common';
+
+export const infoAndExamples = create(({ Markup, Link }) => (
+    <>
+        <p>
+            Do not require people to re-enter information they have already provided via other means – e.g., as part of a previous step in
+            the same form.
+        </p>
+        <h2>Why it matters</h2>
+        <p>
+            The intent of this rule is to reduce the potential for people to have cognitive fatigue due to having to repeatedly enter the
+            same data or recall specific data that had been previously entered. Another benefit here is to reduce the possibility of user
+            error due to a memory lapse or typo compared to the previous entry of said data. This improves success for individuals with
+            cognitive and learning disabilities and memory impairments.
+        </p>
+
+        <h2>How to fix</h2>
+        <p>
+            To fix this issue, ensure all previously provided information auto-populates into the recurring form fields. If this scenario if
+            not possible, provide a mechanism for the user to select the previously populated information for re-entry. The objective of
+            this technique is to provide information that was previously provided by the user or by the system, rather than requiring the
+            user to remember and re-enter the information from a previous step.
+        </p>
+
+        <h2>Example</h2>
+        <Markup.PassFail
+            failText={
+                <p>
+                    A website provides no means to pre-populate information of the address entered by the user in the previous step and
+                    create repetitive actions and redundant entries.
+                </p>
+            }
+            passText={
+                <p>
+                    Populate previously entered information with a trigger: An ecommerce site provides a checkbox that triggers the shipping
+                    address to be pre-populated based on the billing address the user had entered in a previous step.
+                </p>
+            }
+        />
+        <h2>More examples</h2>
+        <h3>WCAG success criteria</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html#:~:text=Redundant%20Entry%20is%20asking%20for%20the%20website%20content,essential%20purposes%20such%20as%20asking%20for%20a%20password.">
+                Understanding Success Criterion 3.3.7: Redundant Entry | WAI | W3C
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Sufficient techniques</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG22/Techniques/general/G221">
+                G221: Provide data from a previous step in a process | WAI | W3C
+            </Markup.HyperLink>
+        </Markup.Links>
+        <h3>Additional Guidance</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/TR/coga-gap-analysis/#table3">
+                Cognitive Accessibility Roadmap and Gap Analysis (w3.org)
+            </Markup.HyperLink>
+            <Markup.HyperLink href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern">
+                Making Content Usable for People with Cognitive and Learning Disabilities (w3.org)
+            </Markup.HyperLink>
+        </Markup.Links>
+    </>
+));

--- a/src/content/test/cognitive/redundant-entry.tsx
+++ b/src/content/test/cognitive/redundant-entry.tsx
@@ -18,7 +18,7 @@ export const infoAndExamples = create(({ Markup, Link }) => (
 
         <h2>How to fix</h2>
         <p>
-            To fix this issue, ensure all previously provided information auto-populates into the recurring form fields. If this scenario if
+            To fix this issue, ensure all previously provided information auto-populates into the recurring form fields. If this scenario is
             not possible, provide a mechanism for the user to select the previously populated information for re-entry. The objective of
             this technique is to provide information that was previously provided by the user or by the system, rather than requiring the
             user to remember and re-enter the information from a previous step.
@@ -29,7 +29,7 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             failText={
                 <p>
                     A website provides no means to pre-populate information of the address entered by the user in the previous step and
-                    create repetitive actions and redundant entries.
+                    creates repetitive actions and redundant entries.
                 </p>
             }
             passText={

--- a/src/content/test/index.ts
+++ b/src/content/test/index.ts
@@ -3,6 +3,7 @@
 import { adaptableContent } from './adaptable-content';
 import { audioVideoOnly } from './audio-video-only';
 import { automatedChecks } from './automated-checks';
+import { cognitive } from './cognitive';
 import { contrast } from './contrast';
 import { customWidgets } from './custom-widgets';
 import { errors } from './errors';
@@ -24,7 +25,6 @@ import { semantics } from './semantics';
 import { sensory } from './sensory';
 import { sequence } from './sequence';
 import { timedEvents } from './timed-events';
-import { cognitive } from './cognitive';
 
 export const test = {
     headings,

--- a/src/content/test/index.ts
+++ b/src/content/test/index.ts
@@ -24,6 +24,7 @@ import { semantics } from './semantics';
 import { sensory } from './sensory';
 import { sequence } from './sequence';
 import { timedEvents } from './timed-events';
+import { cognitive } from './cognitive';
 
 export const test = {
     headings,
@@ -50,4 +51,5 @@ export const test = {
     automatedChecks,
     pointerMotion,
     contrast,
+    cognitive,
 };

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -4527,7 +4527,7 @@ exports[`Guidance Content pages test/cognitive/authentication/infoAndExamples ma
         Why it matters
       </h2>
       <p>
-        This is value for people with certain cognitive disabilities to ensure that there is an accessible, easy-to-use, and secure method to log in. Most Web sites rely on usernames and passwords for logging in. Memorizing or transcribing a username, password, or one-time verification code places a very high or impossible burden upon people with certain cognitive disabilities.
+        This is valuable for people with certain cognitive disabilities to ensure that there is an accessible, easy-to-use, and secure method to log in. Most Web sites rely on usernames and passwords for logging in. Memorizing or transcribing a username, password, or one-time verification code places a very high or impossible burden upon people with certain cognitive disabilities.
       </p>
       <h2>
         How to fix
@@ -4810,7 +4810,7 @@ exports[`Guidance Content pages test/cognitive/guidance matches the snapshot 1`]
               )
             </h3>
             <h3>
-              Create systems with 2-factor authentication systems with verification codes to prevent higher cognitive recall. (
+              Create systems with 2-factor authentication with verification codes to prevent higher cognitive recall. (
               <a
                 class="ms-Link insights-link root-000"
                 href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
@@ -5056,7 +5056,7 @@ exports[`Guidance Content pages test/cognitive/redundantEntry/infoAndExamples ma
         How to fix
       </h2>
       <p>
-        To fix this issue, ensure all previously provided information auto-populates into the recurring form fields. If this scenario if not possible, provide a mechanism for the user to select the previously populated information for re-entry. The objective of this technique is to provide information that was previously provided by the user or by the system, rather than requiring the user to remember and re-enter the information from a previous step.
+        To fix this issue, ensure all previously provided information auto-populates into the recurring form fields. If this scenario is not possible, provide a mechanism for the user to select the previously populated information for re-entry. The objective of this technique is to provide information that was previously provided by the user or by the system, rather than requiring the user to remember and re-enter the information from a previous step.
       </p>
       <h2>
         Example
@@ -5100,7 +5100,7 @@ exports[`Guidance Content pages test/cognitive/redundantEntry/infoAndExamples ma
             </h3>
           </div>
           <p>
-            A website provides no means to pre-populate information of the address entered by the user in the previous step and create repetitive actions and redundant entries.
+            A website provides no means to pre-populate information of the address entered by the user in the previous step and creates repetitive actions and redundant entries.
           </p>
         </div>
         <div

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -4741,7 +4741,7 @@ exports[`Guidance Content pages test/cognitive/guidance matches the snapshot 1`]
       Cognitive and learning disabilities include long-term, short-term, and permanent difficulties relating to cognitive functions, such as:
       <ul>
         <li>
-          learning, communication, reading, writing, or math,
+          learning, communication, reading, writing, or mathematics,
         </li>
         <li>
           ability to understand or process new or complex information and learn new skills, with a reduced ability to cope independently, and/or

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -4889,41 +4889,6 @@ exports[`Guidance Content pages test/cognitive/guidance matches the snapshot 1`]
                 Memory barriers stop people with cognitive disabilities from using content. This includes long passwords to log in and voice menus that involve remembering a specific number or term. Make sure there is an easier option for people who need it.
               </li>
             </ul>
-            <h3>
-              Don't use 
-              <span
-                class="insights-code"
-              >
-                display:none
-              </span>
-              , 
-              <span
-                class="insights-code"
-              >
-                visibility:hidden
-              </span>
-               or 
-              <span
-                class="insights-code"
-              >
-                aria-hidden
-              </span>
-               to make headings invisible 
-              <em>
-                only
-              </em>
-               to sighted users. (a11y tech tip)
-            </h3>
-            <ul>
-              <li>
-                Those properties make headings unavailable to everyone, including assistive technology users. Use this CSS instead: 
-                <span
-                  class="insights-code"
-                >
-                  className="element-invisible"
-                </span>
-              </li>
-            </ul>
           </div>
         </div>
       </div>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -4520,9 +4520,510 @@ exports[`Guidance Content pages test/cognitive/authentication/infoAndExamples ma
     <div
       class="content"
     >
+      <p>
+        People with cognitive issues relating to memory, reading (for example, dyslexia), numbers (for example, dyscalculia), or perception-processing limitations will be able to authenticate irrespective of the level of their cognitive abilities.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        This is value for people with certain cognitive disabilities to ensure that there is an accessible, easy-to-use, and secure method to log in. Most Web sites rely on usernames and passwords for logging in. Memorizing or transcribing a username, password, or one-time verification code places a very high or impossible burden upon people with certain cognitive disabilities.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Ensure that login functionalities in the system don't make people solve, recall, or transcribe something to log in. Consider using the following techniques to make authentication more accessible such as:
+      </p>
+      <ul>
+        <li>
+          Copy & paste functionality is enabled.
+        </li>
+        <li>
+          2-factor authentication systems with verification codes to prevent higher cognitive recall.
+        </li>
+      </ul>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="var(--neutral-0)"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            A fieldset that prompts a user to "Enter the 2nd, 6th and last characters of your password", with separate input fields for each character.
+          </p>
+          <p>
+            See more failure examples below.
+          </p>
+        </div>
+        <div
+          class="fail-example"
+        >
+          <p>
+            The block paste functionality for the website is blocked and user is unable to copy credentials into the login form.
+          </p>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="var(--neutral-0)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            A social media website has a username and password based login mechanism. As part of the forgotten password feature, there is a separate link to login with an email. When the user enters their email and submits the form, the site sends an email to the user. Clicking the link in the email opens the website and the user is logged in.
+          </p>
+        </div>
+        <div
+          class="pass-example"
+        >
+          <p>
+            A web site does not block paste functionality. The user is able to use a third-party password manager to store credentials, copy them, and paste them directly into a login form.
+          </p>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 3.3.8: Accessible Authentication
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG22/Techniques/html/H100"
+          target="_blank"
+        >
+          Providing properly marked up email and password inputs
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218"
+          target="_blank"
+        >
+          Email link authentication
+        </a>
+      </div>
+      <h3>
+        Additional Guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/TR/coga-gap-analysis/#table3"
+          target="_blank"
+        >
+          Cognitive Accessibility Roadmap and Gap Analysis
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/TR/coga-usable/"
+          target="_blank"
+        >
+          Making Content Usable for People with Cognitive and Learning Disabilities
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG22/Techniques/failures/F109"
+          target="_blank"
+        >
+          Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Guidance Content pages test/cognitive/guidance matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
       <h1>
-        Cannot find test/cognitive/authentication/infoAndExamples
+        Cognitive
       </h1>
+      <h2>
+        Why it matters
+      </h2>
+      Cognitive and learning disabilities include long-term, short-term, and permanent difficulties relating to cognitive functions, such as:
+      <ul>
+        <li>
+          learning, communication, reading, writing, or math,
+        </li>
+        <li>
+          ability to understand or process new or complex information and learn new skills, with a reduced ability to cope independently, and/or
+        </li>
+        <li>
+          memory and attention or visual, language, or numerical thinking.
+        </li>
+      </ul>
+      <p>
+        Web page design & structure can make content inaccessible to people with cognitive and learning disabilities. For example, people with impaired short-term memory may be unable to recall passwords, remember access codes, or have trouble remembering unfamiliar iconography. Additionally, people with cognitive and learning disabilities may need more support or time to complete a new process or an authentication task.
+      </p>
+      <p>
+        It is important designs are created while considering the cognitive load they require of their users, as many people may struggle with cognitive fatigue when completing complex, multi-stage processes. For instance, tasks like filling out forms while entering important or sensitive data correctly or just trying to locate the content or feature that they need. Designs need to consistently provide support to help minimize errors and complete their task.
+      </p>
+      <div
+        class="columns"
+      >
+        <div
+          class="column"
+        >
+          <div
+            class="do-header"
+          >
+            <h2>
+              Do
+            </h2>
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="var(--neutral-0)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="do-section"
+          >
+            <h3>
+              Provide users functionality to Copy & paste passwords for authentication. (
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
+                target="_blank"
+              >
+                WCAG 3.3.8
+              </a>
+              )
+            </h3>
+            <h3>
+              Create systems with 2-factor authentication systems with verification codes to prevent higher cognitive recall. (
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
+                target="_blank"
+              >
+                WCAG 3.3.8
+              </a>
+              )
+            </h3>
+          </div>
+        </div>
+        <div
+          class="column"
+        >
+          <div
+            class="dont-header"
+          >
+            <h2>
+              Don't
+            </h2>
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="var(--neutral-0)"
+                />
+              </svg>
+            </span>
+          </div>
+          <div
+            class="dont-section"
+          >
+            <h3>
+              Don't rely on users memorizing or transcribing a username, password, or one-time verification code. (
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
+                target="_blank"
+              >
+                WCAG 3.3.8
+              </a>
+              )
+            </h3>
+            <h3>
+              Don't require people to re-enter information they have already provided via other means. (
+              <a
+                class="ms-Link insights-link root-000"
+                href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html"
+                target="_blank"
+              >
+                WCAG 3.3.7
+              </a>
+              )
+            </h3>
+            <ul>
+              <li>
+                Ensure processes do not rely on memory.
+              </li>
+              <li>
+                Memory barriers stop people with cognitive disabilities from using content. This includes long passwords to log in and voice menus that involve remembering a specific number or term. Make sure there is an easier option for people who need it.
+              </li>
+            </ul>
+            <h3>
+              Don't use 
+              <span
+                class="insights-code"
+              >
+                display:none
+              </span>
+              , 
+              <span
+                class="insights-code"
+              >
+                visibility:hidden
+              </span>
+               or 
+              <span
+                class="insights-code"
+              >
+                aria-hidden
+              </span>
+               to make headings invisible 
+              <em>
+                only
+              </em>
+               to sighted users. (a11y tech tip)
+            </h3>
+            <ul>
+              <li>
+                Those properties make headings unavailable to everyone, including assistive technology users. Use this CSS instead: 
+                <span
+                  class="insights-code"
+                >
+                  className="element-invisible"
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <h2>
+        Learn more
+      </h2>
+      <h3>
+        Reduce Redundant Entry
+      </h3>
+      <h4>
+        WCAG success Criteria
+      </h4>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html#:~:text=Redundant%20Entry%20is%20asking%20for%20the%20website%20content,essential%20purposes%20such%20as%20asking%20for%20a%20password."
+        target="_blank"
+      >
+        Understanding Success Criterion 3.3.7: Redundant Entry
+      </a>
+      <h4>
+        Sufficient techniques
+      </h4>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/WAI/WCAG22/Techniques/general/G221"
+        target="_blank"
+      >
+        Provide data from a previous step in a process
+      </a>
+      <h4>
+        Additional guidance
+      </h4>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/TR/coga-gap-analysis/#table3"
+        target="_blank"
+      >
+        Cognitive Accessibility Roadmap and Gap Analysis
+      </a>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/TR/coga-usable/"
+        target="_blank"
+      >
+        Making Content Usable for People with Cognitive and Learning Disabilities
+      </a>
+      <h3>
+        Provide accessible authentication
+      </h3>
+      <h4>
+        WCAG success Criteria
+      </h4>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
+        target="_blank"
+      >
+        Understanding Success Criterion 3.3.8: Accessible Authentication
+      </a>
+      <h4>
+        Sufficient techniques
+      </h4>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/WAI/WCAG22/Techniques/html/H100"
+        target="_blank"
+      >
+        Providing properly marked up email and password inputs
+      </a>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/WAI/WCAG22/Techniques/general/G218"
+        target="_blank"
+      >
+        Email link authentication
+      </a>
+      <h4>
+        Additional guidance and common failures
+      </h4>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/TR/coga-gap-analysis/#table3"
+        target="_blank"
+      >
+        Cognitive Accessibility Roadmap and Gap Analysis
+      </a>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern"
+        target="_blank"
+      >
+        Making Content Usable for People with Cognitive and Learning Disabilities
+      </a>
+      <a
+        class="ms-Link insights-link root-000"
+        href="https://www.w3.org/WAI/WCAG22/Techniques/failures/F109"
+        target="_blank"
+      >
+        Failure of Success Criterion 3.3.8 and 3.3.9 due to preventing password or code re-entry in the same format
+      </a>
     </div>
     <div
       class="content-right"
@@ -4542,9 +5043,160 @@ exports[`Guidance Content pages test/cognitive/redundantEntry/infoAndExamples ma
     <div
       class="content"
     >
-      <h1>
-        Cannot find test/cognitive/redundantEntry/infoAndExamples
-      </h1>
+      <p>
+        Do not require people to re-enter information they have already provided via other means - e.g., as part of a previous step in the same form.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        The intent of this rule is to reduce the potential for people to have cognitive fatigue due to having to repeatedly enter the same data or recall specific data that had been previously entered. Another benefit here is to reduce the possibility of user error due to a memory lapse or typo compared to the previous entry of said data. This improves success for individuals with cognitive and learning disabilities and memory impairments.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        To fix this issue, ensure all previously provided information auto-populates into the recurring form fields. If this scenario if not possible, provide a mechanism for the user to select the previously populated information for re-entry. The objective of this technique is to provide information that was previously provided by the user or by the system, rather than requiring the user to remember and re-enter the information from a previous step.
+      </p>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="var(--neutral-0)"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            A website provides no means to pre-populate information of the address entered by the user in the previous step and create repetitive actions and redundant entries.
+          </p>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                aria-hidden="true"
+                fill="none"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="var(--neutral-0)"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            Populate previously entered information with a trigger: An ecommerce site provides a checkbox that triggers the shipping address to be pre-populated based on the billing address the user had entered in a previous step.
+          </p>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html#:~:text=Redundant%20Entry%20is%20asking%20for%20the%20website%20content,essential%20purposes%20such%20as%20asking%20for%20a%20password."
+          target="_blank"
+        >
+          Understanding Success Criterion 3.3.7: Redundant Entry
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG22/Techniques/general/G221"
+          target="_blank"
+        >
+          Provide data from a previous step in a process
+        </a>
+      </div>
+      <h3>
+        Additional Guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/TR/coga-gap-analysis/#table3"
+          target="_blank"
+        >
+          Cognitive Accessibility Roadmap and Gap Analysis
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/TR/coga-usable/#make-it-easy-%20%20%20%20%20%20%20%20%20%20%20%20%20to-find-help-and-give-feedback-pattern"
+          target="_blank"
+        >
+          Making Content Usable for People with Cognitive and Learning Disabilities
+        </a>
+      </div>
     </div>
     <div
       class="content-right"

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -4509,6 +4509,50 @@ exports[`Guidance Content pages test/automatedChecks/guidance matches the snapsh
 </DocumentFragment>
 `;
 
+exports[`Guidance Content pages test/cognitive/authentication/infoAndExamples matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Cannot find test/cognitive/authentication/infoAndExamples
+      </h1>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Guidance Content pages test/cognitive/redundantEntry/infoAndExamples matches the snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Cannot find test/cognitive/redundantEntry/infoAndExamples
+      </h1>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Guidance Content pages test/contrast/graphics/infoAndExamples matches the snapshot 1`] = `
 <DocumentFragment>
   <div

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -250,6 +250,10 @@ exports[`DetailsViewBody render render 1`] = `
                 "enabled": false,
                 "stepStatus": {},
               },
+              "cognitive": {
+                "enabled": false,
+                "stepStatus": {},
+              },
               "color": {
                 "enabled": false,
                 "stepStatus": {},
@@ -626,6 +630,10 @@ exports[`DetailsViewBody render render 1`] = `
                   "stepStatus": {},
                 },
                 "automated-checks": {
+                  "enabled": false,
+                  "stepStatus": {},
+                },
+                "cognitive": {
                   "enabled": false,
                   "stepStatus": {},
                 },
@@ -1020,6 +1028,10 @@ exports[`DetailsViewBody render render 1`] = `
                       "stepStatus": {},
                     },
                     "automated-checks": {
+                      "enabled": false,
+                      "stepStatus": {},
+                    },
+                    "cognitive": {
                       "enabled": false,
                       "stepStatus": {},
                     },

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -338,6 +338,10 @@ exports[`DetailsViewContent render renders normally 1`] = `
               "enabled": false,
               "stepStatus": {},
             },
+            "cognitive": {
+              "enabled": false,
+              "stepStatus": {},
+            },
             "color": {
               "enabled": false,
               "stepStatus": {},

--- a/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-visualization-store-data-generator.test.ts.snap
@@ -147,6 +147,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState generates t
         "enabled": false,
         "stepStatus": {},
       },
+      "type-41": {
+        "enabled": false,
+        "stepStatus": {},
+      },
     },
     "quickAssess": {
       "type-10": {
@@ -318,6 +322,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
       "enabled": false,
       "stepStatus": {},
     },
+    "type-41": {
+      "enabled": false,
+      "stepStatus": {},
+    },
   },
   "quickAssess": {
     "type-10": {
@@ -485,6 +493,10 @@ exports[`InitialVisualizationStoreDataGenerator.generateInitialState overwrites 
       "stepStatus": {},
     },
     "type-40": {
+      "enabled": false,
+      "stepStatus": {},
+    },
+    "type-41": {
       "enabled": false,
       "stepStatus": {},
     },


### PR DESCRIPTION
#### Details

This PR creates the "Cognitive" Assessment category, which includes:
* Getting Started (and guidance page)
  * ![screen shot of Getting Started for Cognitive](https://github.com/microsoft/accessibility-insights-web/assets/3230904/93d75f26-e552-4a3f-81ad-2ca2f7a3aca9)
* Redundant Entry (and info/examples content)
  * ![screen shot of redundant entry requirement](https://github.com/microsoft/accessibility-insights-web/assets/3230904/f0dad936-e4ab-43a4-93f1-cccb27d4e646)
* Authentication (and info/examples content)
  * ![screen shot of authentication requirement](https://github.com/microsoft/accessibility-insights-web/assets/3230904/ee1735b5-0395-465e-b1e4-99d6952ccb9e)
  

![screenshot of left navigation showing 25 Cognitive with Getting Started, 25.1 Redundant Entry, and 25.2 Authentication](https://github.com/microsoft/accessibility-insights-web/assets/3230904/306baae2-4ecb-452d-972d-eb82944ac8ea)



##### Motivation

feature work

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
