### PR TITLE
feat(wcag-2-2): Update what's new links for WCAG 2.2

### DIFF
--- a/src/common/constants/link-data-sources.ts
+++ b/src/common/constants/link-data-sources.ts
@@ -17,8 +17,8 @@ export const assessmentLinkDataSource: HyperlinkDefinition[] = [
         text: 'Ask a question',
     },
     {
-        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/',
-        text: 'New WCAG 2.1 success criteria',
+        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/',
+        text: 'New WCAG 2.2 success criteria',
     },
 ];
 
@@ -36,7 +36,7 @@ export const quickAssessLinkDataSource: HyperlinkDefinition[] = [
         text: 'Ask a question',
     },
     {
-        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/',
-        text: 'New WCAG 2.1 success criteria',
+        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/',
+        text: 'New WCAG 2.2 success criteria',
     },
 ];


### PR DESCRIPTION
#### Details
This PR updates the "what's new in WCAG 2.1" links in the extension for WCAG 2.2.

##### Motivation
Related to WCAG 2.2 update, but I'd consider it non-blocking and should be checked into the next release.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
