### PR TITLE
feat(1ES pipeline Migration): Migrated "publish accessibility-insights-report to npm" pipeline to 1ES templates

### DIFF
--- a/pipeline/build-package-report.yaml
+++ b/pipeline/build-package-report.yaml
@@ -19,10 +19,10 @@ extends:
             image: ubuntu-22.04-secure
             name: $(a11yInsightsPool)
         sdl:
-          sourceAnalysisPool:
-            name: $(a11yInsightsPool)
-	        image: windows-2022-secure
-            os: windows
+            sourceAnalysisPool:
+                name: $(a11yInsightsPool)
+                image: windows-2022-secure
+                os: windows
         stages:
             - stage: Stage
               jobs:

--- a/pipeline/build-package-report.yaml
+++ b/pipeline/build-package-report.yaml
@@ -1,6 +1,31 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-jobs:
-    - template: build-package.template.yaml
-      parameters:
-          suffix: report
+
+resources:
+    repositories:
+        - repository: self
+          type: git
+          ref: refs/heads/main
+        - repository: 1esPipelines
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+    parameters:
+        pool:
+            os: linux
+            image: ubuntu-22.04-secure
+            name: $(a11yInsightsPool)
+        sdl:
+          sourceAnalysisPool:
+            name: $(a11yInsightsPool)
+	        image: windows-2022-secure
+            os: windows
+        stages:
+            - stage: Stage
+              jobs:
+                  - template: build-package.template.yaml
+                    parameters:
+                        suffix: report

--- a/pipeline/build-package-report.yaml
+++ b/pipeline/build-package-report.yaml
@@ -26,6 +26,6 @@ extends:
         stages:
             - stage: Stage
               jobs:
-                  - template: build-package.template.yaml@self
+                  - template: pipeline/build-package.template.yaml@self
                     parameters:
                         suffix: report

--- a/pipeline/build-package-report.yaml
+++ b/pipeline/build-package-report.yaml
@@ -26,6 +26,6 @@ extends:
         stages:
             - stage: Stage
               jobs:
-                  - template: build-package.template.yaml
+                  - template: build-package.template.yaml@self
                     parameters:
                         suffix: report

--- a/pipeline/build-package-ui.yaml
+++ b/pipeline/build-package-ui.yaml
@@ -1,6 +1,31 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-jobs:
-    - template: build-package.template.yaml
-      parameters:
-          suffix: ui
+
+resources:
+    repositories:
+        - repository: self
+          type: git
+          ref: refs/heads/main
+        - repository: 1esPipelines
+          type: git
+          name: 1ESPipelineTemplates/1ESPipelineTemplates
+          ref: refs/tags/release
+
+extends:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+    parameters:
+        pool:
+            os: linux
+            image: ubuntu-22.04-secure
+            name: $(a11yInsightsPool)
+        sdl:
+            sourceAnalysisPool:
+              name: $(a11yInsightsPool)
+	            image: windows-2022-secure
+              os: windows
+        stages:
+            - stage: Stage
+              jobs:
+                  - template: build-package.template.yaml
+                    parameters:
+                        suffix: ui

--- a/pipeline/build-package-ui.yaml
+++ b/pipeline/build-package-ui.yaml
@@ -26,6 +26,6 @@ extends:
         stages:
             - stage: Stage
               jobs:
-                  - template: build-package.template.yaml@self
+                  - template: pipeline/build-package.template.yaml@self
                     parameters:
                         suffix: ui

--- a/pipeline/build-package-ui.yaml
+++ b/pipeline/build-package-ui.yaml
@@ -26,6 +26,6 @@ extends:
         stages:
             - stage: Stage
               jobs:
-                  - template: build-package.template.yaml
+                  - template: build-package.template.yaml@self
                     parameters:
                         suffix: ui

--- a/pipeline/build-package-ui.yaml
+++ b/pipeline/build-package-ui.yaml
@@ -20,9 +20,9 @@ extends:
             name: $(a11yInsightsPool)
         sdl:
             sourceAnalysisPool:
-              name: $(a11yInsightsPool)
-	            image: windows-2022-secure
-              os: windows
+                name: $(a11yInsightsPool)
+                image: windows-2022-secure
+                os: windows
         stages:
             - stage: Stage
               jobs:

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -7,8 +7,8 @@ parameters:
 jobs:
     - job: 'build_and_publish_package'
 
-      pool:
-          vmImage: 'ubuntu-20.04'
+      #pool:
+      #    vmImage: 'ubuntu-20.04'
 
       steps:
           - template: install-node-prerequisites.yaml

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -7,9 +7,6 @@ parameters:
 jobs:
     - job: 'build_and_publish_package'
 
-      #pool:
-      #    vmImage: 'ubuntu-20.04'
-
       steps:
           - template: install-node-prerequisites.yaml
 


### PR DESCRIPTION
#### Details

Migrated publish accessibility-insights-report to npm to 1ES templates. Tested the updated pipeline and it running as expected and have verified the artifacts generated with old run. I failed npm published task intentionally in test run as I do not want publish package from my feature branch.

I also updated build-package-ui.yaml because it is also referring the same template which is referred by build-package-report.yaml

##### Motivation

[User Story 2126539](https://dev.azure.com/mseng/1ES/_workitems/edit/2126539): [Web] Migrate "publish accessibility-insights-report to npm" to 1ES PT

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [na] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [na ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [na] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [na] (UI changes only) Added screenshots/GIFs to description above
- [na] (UI changes only) Verified usability with NVDA/JAWS
