### PR TITLE
chore(enzyme-migration): Add override functions for when we need functionality from mocked components

### DIFF
--- a/src/tests/unit/mock-helpers/mock-module-helpers.tsx
+++ b/src/tests/unit/mock-helpers/mock-module-helpers.tsx
@@ -29,7 +29,34 @@ export function mockReactComponents(components: any[]) {
     });
 }
 
-function mockReactComponent<T extends React.ComponentClass<P>, P = any>(component, elementName?) {
+export function useOriginalReactElements(library: string, components: any[]) {
+    const actualLibrary = jest.requireActual(library);
+    components.forEach(component => {
+        const mockComponent = jest.requireMock(library)[component];
+        if (
+            actualLibrary[component].prototype &&
+            actualLibrary[component].prototype.isReactComponent
+        ) {
+            const mockClass = () => ({
+                ...mockComponent,
+                render: actualLibrary[component].prototype.render,
+            });
+            (mockComponent as any).mockImplementation(mockClass);
+        } else {
+            if ((mockComponent as any).render?.mockImplementation) {
+                mockComponent.render.mockImplementation(actualLibrary[component].render);
+            }
+            if ((mockComponent as any).mockImplementation) {
+                (mockComponent as any).mockImplementation(actualLibrary[component]);
+            }
+        }
+    });
+}
+
+export function mockReactComponent<T extends React.ComponentClass<P>, P = any>(
+    component,
+    elementName?,
+) {
     if (component !== undefined) {
         const name =
             elementName || component.displayName
@@ -44,9 +71,7 @@ function mockReactComponent<T extends React.ComponentClass<P>, P = any>(componen
             );
         }
         const mockFunction = mockReactElement<P>(name);
-
         if (component.prototype && component.prototype.isReactComponent) {
-            //mock the class
             const mockClass = (props: P, context?: any, ...rest: any[]) => ({
                 render: () => mockFunction(props, ...rest),
                 props,

--- a/src/tests/unit/mock-helpers/mock-module-helpers.tsx
+++ b/src/tests/unit/mock-helpers/mock-module-helpers.tsx
@@ -53,10 +53,7 @@ export function useOriginalReactElements(library: string, components: any[]) {
     });
 }
 
-export function mockReactComponent<T extends React.ComponentClass<P>, P = any>(
-    component,
-    elementName?,
-) {
+function mockReactComponent<T extends React.ComponentClass<P>, P = any>(component, elementName?) {
     if (component !== undefined) {
         const name =
             elementName || component.displayName


### PR DESCRIPTION

#### Details

This PR adds the `useOriginalReactElements` function to our mock module helpers. This function can be called in individual tests or in the `beforeEach` method to override any mocking previously done to React components for those tests. This allows us to have clean snapshots while also fully rendering components when we need to interact with them (e.g. button components) for tests in the same file.

##### Motivation

feature work

##### Context

This is part of our migration from Enzyme to React Testing Library

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
