### PR TITLE
fix: Update WCAG 2.1 AA references to include WCAG 2.2 AA

### DIFF
--- a/src/DetailsView/components/overview-content/overview-heading-intro.tsx
+++ b/src/DetailsView/components/overview-content/overview-heading-intro.tsx
@@ -12,8 +12,8 @@ export const OverviewHeadingIntro = NamedFC('OverviewHeadingIntro', () => {
         <div className={styles.overviewHeadingContent}>
             This page contains a summary that indicates the progress of your assessment. An
             assessment is a manual experience in which you navigate through a set of tests that
-            cover all WCAG 2.1 AA success criteria. Each test has one or more requirements that can
-            be:
+            cover all WCAG 2.1 AA and 2.2 AA success criteria. Each test has one or more
+            requirements that can be:
             <ul>
                 <li>Automated</li>
                 <li>Assisted</li>

--- a/src/DetailsView/components/overview-content/overview-help-section-about.tsx
+++ b/src/DetailsView/components/overview-content/overview-help-section-about.tsx
@@ -13,7 +13,8 @@ export const OverviewHelpSectionAboutForQuickAssess = NamedFC('OverviewHelpSecti
             <p>
                 Quick Assess is a shortened version of Assessment. In this experience, you will
                 navigate through a set of 10 assisted and manual tests that should take less than 30
-                minutes to cover limited aspects of the WCAG 2.1 AA success criteria.
+                minutes to cover limited aspects of the WCAG 2.1 AA and WCAG 2.2 AA success
+                criteria.
             </p>
         </>
     );

--- a/src/reports/components/assessment-report-body-header.tsx
+++ b/src/reports/components/assessment-report-body-header.tsx
@@ -9,8 +9,8 @@ export class AssessmentReportBodyHeader extends React.Component {
                 <h1>Assessment report</h1>
                 <p>
                     This report shows the overall accessibility of the website or web app through a
-                    combination of automated and manual tests that cover all the WCAG 2.1 AA success
-                    criteria.
+                    combination of automated and manual tests that cover all the WCAG 2.1 AA and 2.2
+                    AA success criteria.
                 </p>
             </div>
         );

--- a/src/reports/components/quick-assess-report-body-header.tsx
+++ b/src/reports/components/quick-assess-report-body-header.tsx
@@ -9,7 +9,7 @@ export class QuickAssessReportBodyHeader extends React.Component {
                 <h1>QuickAssess report</h1>
                 <p>
                     This report shows the results from a combination of assisted and manual tests
-                    that cover limited aspects of the WCAG 2.1 AA success criteria.
+                    that cover limited aspects of the WCAG 2.1 AA and 2.2 AA success criteria.
                 </p>
             </div>
         );

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-body-header.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-body-header.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`AssessmentReportBodyHeader render render function test 1`] = `
     Assessment report
   </h1>
   <p>
-    This report shows the overall accessibility of the website or web app through a combination of automated and manual tests that cover all the WCAG 2.1 AA success criteria.
+    This report shows the overall accessibility of the website or web app through a combination of automated and manual tests that cover all the WCAG 2.1 AA and 2.2 AA success criteria.
   </p>
 </div>
 `;


### PR DESCRIPTION
#### Details

As called out in #7209, when we added WCAG 2.2 tests, we still had a few places in the UX where we referenced "WCAG 2.1 AA success criteria". When we discussed this in triage, the approved updated wording is now "WCAG 2.1 AA and 2.2 AA success criteria". While #7209 was specific to the report, this changes 3 other places in the UX.

##### Screenshots

The text size of the elements has not changed, but GitHub is scaling the screen grabs that are slightly different sizes, hence the potential for these seeming to be different sizes:

Element | Old | New
--- | --- | ---
Assessment Overview | <img width="405" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/f284af96-13f4-4705-a109-b66c4d6acf3b"> |  <img width="401" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/6214ee17-4d5d-48c4-9a65-740262c033e1">
QuickAssess Overview Help | <img width="210" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/8f819126-a85f-4a7d-838b-471c37cb5105"> | <img width="208" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/9793ce6e-b44f-4a16-8bd7-bf723f7fedf7">
Assessment Report | <img width="586" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/33e009ed-acff-46b0-88c8-710cf11a694c"> | <img width="578" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/2c33174c-feb5-4b1f-8a45-fb93f29e54f1">
QuickAsses Report | <img width="581" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/77184ac8-54d6-40a4-b94c-675cf2e39ace"> | <img width="575" alt="image" src="https://github.com/microsoft/accessibility-insights-web/assets/45672944/d779c738-d162-4274-83d7-079850159c7e">

##### Motivation

Address #7209

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #7209
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
