### PR TITLE
chore(deps-dev): Bump @testing-library/jest-dom from 6.2.1 to 6.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "@esbuild-plugins/node-resolve": "^0.2.2",
         "@swc/core": "^1.3.107",
         "@swc/jest": "^0.2.29",
-        "@testing-library/jest-dom": "^6.1.6",
+        "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "12.1.2",
         "@types/chrome": "0.0.256",
         "@types/enzyme": "^3.10.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,9 +2349,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^6.1.6":
-  version: 6.2.1
-  resolution: "@testing-library/jest-dom@npm:6.2.1"
+"@testing-library/jest-dom@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "@testing-library/jest-dom@npm:6.4.2"
   dependencies:
     "@adobe/css-tools": ^4.3.2
     "@babel/runtime": ^7.9.2
@@ -2378,7 +2378,7 @@ __metadata:
       optional: true
     vitest:
       optional: true
-  checksum: 36bb8c23fd102a572bb22e37933c5134c6b4737c9d1ca575d2abde64bd5ffbb5f571caa76c1d8ab0b384670fcc680353f1ef563a2d9a6d46d00c47b4eb38969b
+  checksum: 631aeadbf4e738080ae095242cf1a29a0b4ee2f09c8bdd0d3f00a923707da64c1617e088ba9a961d098481afabdc1d19149fb7ef98edf15132348eb222f345ae
   languageName: node
   linkType: hard
 
@@ -3358,7 +3358,7 @@ __metadata:
     "@microsoft/applicationinsights-web": ^2.8.15
     "@swc/core": ^1.3.107
     "@swc/jest": ^0.2.29
-    "@testing-library/jest-dom": ^6.1.6
+    "@testing-library/jest-dom": ^6.4.2
     "@testing-library/react": 12.1.2
     "@testing-library/user-event": ^14.5.2
     "@types/chrome": 0.0.256


### PR DESCRIPTION
#### Details

Bumps [@testing-library/jest-dom](https://github.com/testing-library/jest-dom) from 6.2.1 to 6.4.2.

##### Motivation

(https://github.com/microsoft/accessibility-insights-web/pull/7234) the ClearlyDefined check was failing due to ClearlyDefined does not have a definition for this package version.

##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #7234 
- [x] Ran `yarn fastpass`
- [na] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [na] (UI changes only) Added screenshots/GIFs to description above
- [na] (UI changes only) Verified usability with NVDA/JAWS
