### PR TITLE
chore: Typescript Cleanup- Part 1 of 3

### DIFF
--- a/src/DetailsView/components/details-view-overlay/scoping-panel/scoping-container.tsx
+++ b/src/DetailsView/components/details-view-overlay/scoping-panel/scoping-container.tsx
@@ -8,10 +8,12 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { InspectMode } from 'common/types/store-data/inspect-modes';
 import { ScopingInputTypes } from 'common/types/store-data/scoping-input-types';
 import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
+import { ScopingPanelDeps } from 'DetailsView/components/details-view-overlay/scoping-panel/scoping-panel';
 import * as React from 'react';
 import styles from './scoping-container.scss';
 
 export interface ScopingContainerProps {
+    deps: ScopingPanelDeps;
     featureFlagData: FeatureFlagStoreData;
     scopingSelectorsData: ScopingStoreData;
     scopingActionMessageCreator: ScopingActionMessageCreator;

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -185,7 +185,6 @@ const detailsViewSwitcherNavs: {
         getSharedAssessmentFunctionalityObjects: switcher => switcher.getQuickAssessObjects(),
         getSelectedAssessmentStoreData: getQuickAssessStoreData,
         getSelectedAssessmentCardSelectionStoreData: getQuickAssessCardSelectionStoreData,
-        shouldShowQuickAssessRequirementView: true,
         getRequirementViewComponentConfiguration:
             getRequirementViewComponentConfigurationForQuickAssess,
         getOverviewHeadingIntro: getNullComponent,

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 import classNames from 'classnames';
 import { CardsViewStoreData } from 'common/components/cards/cards-view-store-data';
+import { HyperlinkDefinition } from 'common/types/hyperlink-definition';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanIncompleteWarningId } from 'common/types/store-data/scan-incomplete-warnings';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { OverviewHeadingIntroFactory } from 'DetailsView/components/overview-content/overview-heading-intro';
+import { OverviewHelpSectionAboutFactory } from 'DetailsView/components/overview-content/overview-help-section-about';
 import {
     QuickAssessToAssessmentDialog,
     QuickAssessToAssessmentDialogDeps,
@@ -80,6 +83,9 @@ export interface DetailsViewBodyProps {
     tabStopRequirementData: TabStopRequirementState;
     dataTransferViewStoreData: DataTransferViewStoreData;
     testViewContainerProvider: TestViewContainerProvider;
+    getOverviewHeadingIntro: OverviewHeadingIntroFactory;
+    linkDataSource: HyperlinkDefinition[];
+    getOverviewHelpSectionAbout: OverviewHelpSectionAboutFactory;
 }
 
 export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {


### PR DESCRIPTION
#### Details

As part of Typescript migration added/removed the error causing fields.
1. src/DetailsView/components/details-view-content.tsx  
- For the above file we were getting errors on getOverviewHeadingIntro, linkDataSource, getOverviewHelpSectionAbout these properties.
- These properties are referred in details-view-switcher-nav.ts, overview-content-container.tsx.
- Hence, we are not removing these properties, and added it in details-view-body.tsx.

2. src/DetailsView/components/details-view-overlay/scoping-panel/scoping-panel.tsx
- We were getting error on deps={this.props.deps}.
- In details-view-overlay.tsx class ScopingPanel is used.
- Hence, we are not removing these properties and added it in scoping-container.tsx

3. Details-view-switcher-nav.ts 
- Got error on shouldShowQuickAssessRequirementView: true, 
- Couldn’t find any reference to the above property in any of the files.  
- Tested it after removing the property. There are no errors and also on UI level couldnt find any issues. 
-Hence, it seems like it is safe to remove it. 
##### Motivation
TypeScript 5.0 has marked some options as deprecated. We can temporarily override these deprecations, but the documented plan is for the ability to override the flag to go away in TypeScript 5.5
<!-- This can be as simple as "addresses issue #123" -->

Associated User story - [User Story 2151430](https://dev.azure.com/mseng/1ES/_workitems/edit/2151430)
##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue:  #(https://github.com/microsoft/accessibility-insights-web/pull/6611)
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
