### PR TITLE
fix: Accessibility Bugs

### DIFF
--- a/src/DetailsView/components/assessment-instance-selected-button.tsx
+++ b/src/DetailsView/components/assessment-instance-selected-button.tsx
@@ -45,7 +45,7 @@ export class AssessmentInstanceSelectedButton extends React.Component<Assessment
                 disabled={!isVisible}
                 onClick={this.onButtonClicked}
                 role="checkbox"
-                aria-checked={isVisualizationEnabled}
+                checked={isVisualizationEnabled}
                 aria-label="Visualization"
             />
         );

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -25,6 +25,7 @@ import {
     LoadAssessmentDialogDeps,
 } from 'DetailsView/components/load-assessment-dialog';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
+import { QuickAssessToAssessmentDialog } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import {
     ReportExportDialogFactoryDeps,
@@ -48,13 +49,12 @@ import {
     TransferToAssessmentButtonDeps,
     TransferToAssessmentButtonProps,
 } from 'DetailsView/components/transfer-to-assessment-button';
+import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { DetailsRightPanelConfiguration } from './details-view-right-panel';
-import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';
-import { QuickAssessToAssessmentDialog } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 
 export type DetailsViewCommandBarDeps = {
     getCurrentDate: () => Date;

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -142,7 +142,7 @@ export class DetailsViewCommandBar extends React.Component<
                 {this.renderInvalidLoadAssessmentDialog()}
                 {this.renderLoadAssessmentDialog()}
                 {this.renderStartOverDialog()}
-                {this.renderMoveToAssessmentDialog()}
+                {this.renderTransferToAssessmentDialog()}
             </div>
         );
     }
@@ -266,17 +266,29 @@ export class DetailsViewCommandBar extends React.Component<
         });
     };
 
-    private renderLoadAssessmentButton = (): JSX.Element | null => {
-        return this.props.switcherNavConfiguration.LoadAssessmentButton({
-            ...this.props,
-            handleLoadAssessmentButtonClick: this.handleLoadAssessmentButtonClick,
-        });
-    };
-
     private renderTransferToAssessmentButton = (): JSX.Element | null => {
         return this.props.switcherNavConfiguration.TransferToAssessmentButton({
             ...this.props,
             buttonRef: ref => (this.transferToAssessmentDialogCloseFocus = ref ?? undefined),
+        });
+    };
+
+    private renderTransferToAssessmentDialog(): JSX.Element {
+        return (
+            <QuickAssessToAssessmentDialog
+                isShown={
+                    this.props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog
+                }
+                afterDialogDismissed={this.focusTransferToAssessmentButton}
+                {...this.props}
+            />
+        );
+    }
+
+    private renderLoadAssessmentButton = (): JSX.Element | null => {
+        return this.props.switcherNavConfiguration.LoadAssessmentButton({
+            ...this.props,
+            handleLoadAssessmentButtonClick: this.handleLoadAssessmentButtonClick,
         });
     };
 
@@ -383,17 +395,5 @@ export class DetailsViewCommandBar extends React.Component<
         };
 
         return <StartOverDialog {...dialogProps} />;
-    }
-
-    private renderMoveToAssessmentDialog(): JSX.Element {
-        return (
-            <QuickAssessToAssessmentDialog
-                isShown={
-                    this.props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog
-                }
-                afterDialogDismissed={this.focusTransferToAssessmentButton}
-                {...this.props}
-            />
-        );
     }
 }

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -53,6 +53,8 @@ import { ReportGenerator } from 'reports/report-generator';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { DetailsRightPanelConfiguration } from './details-view-right-panel';
+import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';
+import { QuickAssessToAssessmentDialog } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 
 export type DetailsViewCommandBarDeps = {
     getCurrentDate: () => Date;
@@ -105,6 +107,7 @@ export interface DetailsViewCommandBarProps {
     tabStopRequirementData: TabStopRequirementState;
     userConfigurationStoreData: UserConfigurationStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
+    dataTransferViewStoreData: DataTransferViewStoreData;
 }
 export class DetailsViewCommandBar extends React.Component<
     DetailsViewCommandBarProps,
@@ -112,6 +115,7 @@ export class DetailsViewCommandBar extends React.Component<
 > {
     public exportDialogCloseFocus?: IButton;
     public startOverDialogCloseFocus?: IButton;
+    public transferToAssessmentDialogCloseFocus?: IButton;
 
     public constructor(props) {
         super(props);
@@ -119,6 +123,7 @@ export class DetailsViewCommandBar extends React.Component<
             isInvalidLoadAssessmentDialogOpen: false,
             isLoadAssessmentDialogOpen: false,
             isReportExportDialogOpen: false,
+            isMoveToAssessmentDialogOpen: false,
             loadedAssessmentData: {} as VersionedAssessmentData,
             startOverDialogState: 'none',
         };
@@ -137,6 +142,7 @@ export class DetailsViewCommandBar extends React.Component<
                 {this.renderInvalidLoadAssessmentDialog()}
                 {this.renderLoadAssessmentDialog()}
                 {this.renderStartOverDialog()}
+                {this.renderMoveToAssessmentDialog()}
             </div>
         );
     }
@@ -208,6 +214,7 @@ export class DetailsViewCommandBar extends React.Component<
                 buttonRef={ref => {
                     this.exportDialogCloseFocus = ref ?? undefined;
                     this.startOverDialogCloseFocus = ref ?? undefined;
+                    this.transferToAssessmentDialogCloseFocus = ref ?? undefined;
                 }}
             />
         );
@@ -218,6 +225,9 @@ export class DetailsViewCommandBar extends React.Component<
     private dismissReportExportDialog = () => this.setState({ isReportExportDialogOpen: false });
 
     private focusReportExportButton = () => this.exportDialogCloseFocus?.focus();
+
+    private focusTransferToAssessmentButton = () =>
+        this.transferToAssessmentDialogCloseFocus?.focus();
 
     private renderExportButton = () => {
         const shouldShowReportExportButtonProps: ShouldShowReportExportButtonProps = {
@@ -266,6 +276,7 @@ export class DetailsViewCommandBar extends React.Component<
     private renderTransferToAssessmentButton = (): JSX.Element | null => {
         return this.props.switcherNavConfiguration.TransferToAssessmentButton({
             ...this.props,
+            buttonRef: ref => (this.transferToAssessmentDialogCloseFocus = ref ?? undefined),
         });
     };
 
@@ -372,5 +383,17 @@ export class DetailsViewCommandBar extends React.Component<
         };
 
         return <StartOverDialog {...dialogProps} />;
+    }
+
+    private renderMoveToAssessmentDialog(): JSX.Element {
+        return (
+            <QuickAssessToAssessmentDialog
+                isShown={
+                    this.props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog
+                }
+                afterDialogDismissed={this.focusTransferToAssessmentButton}
+                {...this.props}
+            />
+        );
     }
 }

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -30,9 +30,9 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
             hidden: !props.isShown,
             title: 'Continue to Assessment',
             onDismiss: dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog,
-            containerClassName: commonDialogStyles.insightsDialogMainOverride,
             modalProps: {
                 onDismissed: props.afterDialogDismissed,
+                containerClassName: commonDialogStyles.insightsDialogMainOverride,
             },
         };
 

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -30,8 +30,10 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
             hidden: !props.isShown,
             title: 'Continue to Assessment',
             onDismiss: dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog,
-            onDismissed: props.afterDialogDismissed,
             containerClassName: commonDialogStyles.insightsDialogMainOverride,
+            modalProps: {
+                onDismissed: props.afterDialogDismissed,
+            },
         };
 
         const descriptionText =

--- a/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
+++ b/src/DetailsView/components/quick-assess-to-assessment-dialog.tsx
@@ -17,6 +17,7 @@ export type QuickAssessToAssessmentDialogDeps = {
 export interface QuickAssessToAssessmentDialogProps {
     deps: QuickAssessToAssessmentDialogDeps;
     isShown: boolean;
+    afterDialogDismissed: () => void;
 }
 
 export const continueToAssessmentButtonAutomationId = 'continue-to-assessment-button';
@@ -29,6 +30,7 @@ export const QuickAssessToAssessmentDialog = NamedFC<QuickAssessToAssessmentDial
             hidden: !props.isShown,
             title: 'Continue to Assessment',
             onDismiss: dataTransferViewController.hideQuickAssessToAssessmentConfirmDialog,
+            onDismissed: props.afterDialogDismissed,
             containerClassName: commonDialogStyles.insightsDialogMainOverride,
         };
 

--- a/src/DetailsView/components/transfer-to-assessment-button.tsx
+++ b/src/DetailsView/components/transfer-to-assessment-button.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { IRefObject, IButton } from '@fluentui/react';
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { NamedFC } from 'common/react/named-fc';
 import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
@@ -12,6 +13,7 @@ export type TransferToAssessmentButtonDeps = {
 
 export interface TransferToAssessmentButtonProps {
     deps: TransferToAssessmentButtonDeps;
+    buttonRef?: IRefObject<IButton>;
 }
 
 export const transferToAssessmentButtonAutomationId = 'transfer-to-assessment-button';
@@ -26,6 +28,7 @@ export const TransferToAssessmentButton = NamedFC<TransferToAssessmentButtonProp
                 onClick={
                     props.deps.dataTransferViewController.showQuickAssessToAssessmentConfirmDialog
                 }
+                componentRef={props.buttonRef}
             >
                 Move to assessment
             </InsightsCommandButton>

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -11,9 +11,7 @@ import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-na
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
 import { OverviewHeadingIntroFactory } from 'DetailsView/components/overview-content/overview-heading-intro';
 import { OverviewHelpSectionAboutFactory } from 'DetailsView/components/overview-content/overview-help-section-about';
-import {
-    QuickAssessToAssessmentDialogDeps,
-} from 'DetailsView/components/quick-assess-to-assessment-dialog';
+import { QuickAssessToAssessmentDialogDeps } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import { TestViewContainerProvider } from 'DetailsView/components/test-view-container-provider';
 import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -8,10 +8,7 @@ import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { NarrowModeStatus } from 'DetailsView/components/narrow-mode-detector';
-import {
-    QuickAssessToAssessmentDialog,
-    QuickAssessToAssessmentDialogDeps,
-} from 'DetailsView/components/quick-assess-to-assessment-dialog';
+import { QuickAssessToAssessmentDialogDeps } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 import { TabStopsViewStoreData } from 'DetailsView/components/tab-stops/tab-stops-view-store-data';
 import { TestViewContainerProvider } from 'DetailsView/components/test-view-container-provider';
 import { DataTransferViewStoreData } from 'DetailsView/data-transfer-view-store';
@@ -97,7 +94,6 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
                         <div className={styles.detailsViewBodyContentPane}>
                             {this.getTargetPageHiddenBar()}
                             <div className={styles.view} role="main">
-                                {this.renderQuickAssessToAssessmentDialog()}
                                 {this.renderRightPanel()}
                             </div>
                         </div>
@@ -142,16 +138,5 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
 
     private renderRightPanel(): JSX.Element {
         return <this.props.rightPanelConfiguration.RightPanel {...this.props} />;
-    }
-
-    private renderQuickAssessToAssessmentDialog(): JSX.Element {
-        return (
-            <QuickAssessToAssessmentDialog
-                isShown={
-                    this.props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog
-                }
-                deps={this.props.deps}
-            />
-        );
     }
 }

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-body.test.tsx.snap
@@ -61,12 +61,7 @@ exports[`DetailsViewBody render render 1`] = `
           <div
             class="view"
             role="main"
-          >
-            <mock-quickassesstoassessmentconfirmdialog
-              deps="[object Object]"
-              isshown="true"
-            />
-          </div>
+          />
         </div>
       </div>
     </div>
@@ -1905,15 +1900,6 @@ exports[`DetailsViewBody render render: QuickAssessCommandBar props 1`] = `
       },
     },
   },
-}
-`;
-
-exports[`DetailsViewBody render render: QuickAssessToAssessmentConfirmDialog props 1`] = `
-{
-  "deps": {
-    "detailsViewActionMessageCreator": {},
-  },
-  "isShown": true,
 }
 `;
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-instance-selected-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-instance-selected-button.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`AssessmentInstanceSelectedButton render when element is not selected and is not visible 1`] = `
 <DocumentFragment>
   <mock-customizediconbutton
-    aria-checked="false"
     aria-label="Visualization"
+    checked="false"
     classname="instanceVisibilityButton testInstanceSelectedHiddenButton"
     disabled="true"
     iconprops="[object Object]"
@@ -16,8 +16,8 @@ exports[`AssessmentInstanceSelectedButton render when element is not selected an
 exports[`AssessmentInstanceSelectedButton render when element is not selected and is visible 1`] = `
 <DocumentFragment>
   <mock-customizediconbutton
-    aria-checked="false"
     aria-label="Visualization"
+    checked="false"
     classname="instanceVisibilityButton"
     disabled="false"
     iconprops="[object Object]"
@@ -29,8 +29,8 @@ exports[`AssessmentInstanceSelectedButton render when element is not selected an
 exports[`AssessmentInstanceSelectedButton render when element is selected and visible 1`] = `
 <DocumentFragment>
   <mock-customizediconbutton
-    aria-checked="true"
     aria-label="Visualization"
+    checked="true"
     classname="instanceVisibilityButton"
     disabled="false"
     iconprops="[object Object]"
@@ -42,8 +42,8 @@ exports[`AssessmentInstanceSelectedButton render when element is selected and vi
 exports[`AssessmentInstanceSelectedButton render when element is selected but hidden 1`] = `
 <DocumentFragment>
   <mock-customizediconbutton
-    aria-checked="true"
     aria-label="Visualization"
+    checked="true"
     classname="instanceVisibilityButton testInstanceSelectedHiddenButton"
     disabled="true"
     iconprops="[object Object]"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -103,6 +103,7 @@ exports[`DetailsViewCommandBar renders invalid load assessment dialog: invalid l
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -114,6 +115,7 @@ exports[`DetailsViewCommandBar renders invalid load assessment dialog: invalid l
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -128,9 +130,22 @@ exports[`DetailsViewCommandBar renders invalid load assessment dialog: invalid l
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -244,6 +259,7 @@ exports[`DetailsViewCommandBar renders invalid load assessment dialog: invalid l
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="true"
@@ -255,6 +271,7 @@ exports[`DetailsViewCommandBar renders invalid load assessment dialog: invalid l
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -269,9 +286,22 @@ exports[`DetailsViewCommandBar renders invalid load assessment dialog: invalid l
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -385,6 +415,7 @@ exports[`DetailsViewCommandBar renders load assessment dialog: load assessment d
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -396,6 +427,7 @@ exports[`DetailsViewCommandBar renders load assessment dialog: load assessment d
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -410,9 +442,22 @@ exports[`DetailsViewCommandBar renders load assessment dialog: load assessment d
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -526,6 +571,7 @@ exports[`DetailsViewCommandBar renders load assessment dialog: load assessment d
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -537,6 +583,7 @@ exports[`DetailsViewCommandBar renders load assessment dialog: load assessment d
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="true"
@@ -551,9 +598,22 @@ exports[`DetailsViewCommandBar renders load assessment dialog: load assessment d
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -640,6 +700,7 @@ exports[`DetailsViewCommandBar renders report export dialog: export dialog hidde
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -651,6 +712,7 @@ exports[`DetailsViewCommandBar renders report export dialog: export dialog hidde
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -665,9 +727,22 @@ exports[`DetailsViewCommandBar renders report export dialog: export dialog hidde
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -753,6 +828,7 @@ exports[`DetailsViewCommandBar renders report export dialog: export dialog open 
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -764,6 +840,7 @@ exports[`DetailsViewCommandBar renders report export dialog: export dialog open 
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -778,9 +855,22 @@ exports[`DetailsViewCommandBar renders report export dialog: export dialog open 
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -904,6 +994,7 @@ exports[`DetailsViewCommandBar renders start assessment over dialog: start asses
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -915,6 +1006,7 @@ exports[`DetailsViewCommandBar renders start assessment over dialog: start asses
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -929,9 +1021,22 @@ exports[`DetailsViewCommandBar renders start assessment over dialog: start asses
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1052,6 +1157,7 @@ exports[`DetailsViewCommandBar renders start assessment over dialog: start asses
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1063,6 +1169,7 @@ exports[`DetailsViewCommandBar renders start assessment over dialog: start asses
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1077,9 +1184,22 @@ exports[`DetailsViewCommandBar renders start assessment over dialog: start asses
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="assessment"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1203,6 +1323,7 @@ exports[`DetailsViewCommandBar renders start test over dialog: start test over d
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1214,6 +1335,7 @@ exports[`DetailsViewCommandBar renders start test over dialog: start test over d
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1228,9 +1350,22 @@ exports[`DetailsViewCommandBar renders start test over dialog: start test over d
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1351,6 +1486,7 @@ exports[`DetailsViewCommandBar renders start test over dialog: start test over d
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1362,6 +1498,7 @@ exports[`DetailsViewCommandBar renders start test over dialog: start test over d
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1376,9 +1513,286 @@ exports[`DetailsViewCommandBar renders start test over dialog: start test over d
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="test"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DetailsViewCommandBar renders transfer to assessment dialog: transfer to assessment dialog hidden 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="command bar"
+    class="detailsViewCommandBar"
+    role="region"
+  >
+    <div
+      aria-labelledby="switch-to-target"
+      class="detailsViewTargetPage"
+    >
+      <span
+        id="switch-to-target"
+      >
+        Target page: 
+      </span>
+      <mock-newtablinkwithtooltip
+        aria-label="Switch to target page: command-bar-test-tab-title"
+        classname="targetPageLink"
+        role="link"
+        tooltipcontent="Switch to target page: command-bar-test-tab-title"
+      >
+        <span
+          class="targetPageTitle"
+        >
+          command-bar-test-tab-title
+        </span>
+      </mock-newtablinkwithtooltip>
+    </div>
+    <div
+      class="detailsViewCommandButtons"
+    >
+      <button
+        class="ms-Button ms-Button--action ms-Button--command insightsCommandButton root-109"
+        data-automation-id="report-export-button"
+        data-is-focusable="true"
+        type="button"
+      >
+        <span
+          class="ms-Button-flexContainer flexContainer-110"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden="true"
+            class="ms-Icon root-105 ms-Button-icon commandBarButtonIcon icon-112 commandBarButtonIcon"
+            data-icon-name="Export"
+          />
+          <span
+            class="ms-Button-textContainer textContainer-111"
+          >
+            <span
+              class="ms-Button-label label-113"
+              id="id__39"
+            >
+              Export result
+            </span>
+          </span>
+        </span>
+      </button>
+      <div>
+        Transfer to assessment stub
+      </div>
+    </div>
+    <mock-exportdialog
+      deps="[object Object]"
+      description=""
+      featureflagstoredata="[object Object]"
+      htmlexportdata=""
+      htmlfilename=""
+      htmlfileurl="#"
+      isopen="false"
+      jsonexportdata=""
+      jsonfilename=""
+      jsonfileurl="#"
+      reportexportformat="Assessment"
+      reportexportservices="[object Object],[object Object],[object Object]"
+    />
+    <mock-invalidloadassessmentdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isopen="false"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-loadassessmentdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isopen="false"
+      loadedassessmentdata="[object Object]"
+      narrowmodestatus="[object Object]"
+      prevtab="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabid="5"
+      tabstoredata="[object Object]"
+    />
+    <mock-startoverdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      dialogstate="none"
+      featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`DetailsViewCommandBar renders transfer to assessment dialog: transfer to assessment dialog open 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="command bar"
+    class="detailsViewCommandBar"
+    role="region"
+  >
+    <div
+      aria-labelledby="switch-to-target"
+      class="detailsViewTargetPage"
+    >
+      <span
+        id="switch-to-target"
+      >
+        Target page: 
+      </span>
+      <mock-newtablinkwithtooltip
+        aria-label="Switch to target page: command-bar-test-tab-title"
+        classname="targetPageLink"
+        role="link"
+        tooltipcontent="Switch to target page: command-bar-test-tab-title"
+      >
+        <span
+          class="targetPageTitle"
+        >
+          command-bar-test-tab-title
+        </span>
+      </mock-newtablinkwithtooltip>
+    </div>
+    <div
+      class="detailsViewCommandButtons"
+    >
+      <button
+        class="ms-Button ms-Button--action ms-Button--command insightsCommandButton root-109"
+        data-automation-id="report-export-button"
+        data-is-focusable="true"
+        type="button"
+      >
+        <span
+          class="ms-Button-flexContainer flexContainer-110"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden="true"
+            class="ms-Icon root-105 ms-Button-icon commandBarButtonIcon icon-112 commandBarButtonIcon"
+            data-icon-name="Export"
+          />
+          <span
+            class="ms-Button-textContainer textContainer-111"
+          >
+            <span
+              class="ms-Button-label label-113"
+              id="id__39"
+            >
+              Export result
+            </span>
+          </span>
+        </span>
+      </button>
+      <div>
+        Transfer to assessment stub
+      </div>
+    </div>
+    <mock-exportdialog
+      deps="[object Object]"
+      description=""
+      featureflagstoredata="[object Object]"
+      htmlexportdata=""
+      htmlfilename=""
+      htmlfileurl="#"
+      isopen="false"
+      jsonexportdata=""
+      jsonfilename=""
+      jsonfileurl="#"
+      reportexportformat="Assessment"
+      reportexportservices="[object Object],[object Object],[object Object]"
+    />
+    <mock-invalidloadassessmentdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isopen="false"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-loadassessmentdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isopen="false"
+      loadedassessmentdata="[object Object]"
+      narrowmodestatus="[object Object]"
+      prevtab="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabid="5"
+      tabstoredata="[object Object]"
+    />
+    <mock-startoverdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      dialogstate="none"
+      featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="true"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1435,6 +1849,7 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1446,6 +1861,7 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1460,9 +1876,22 @@ exports[`DetailsViewCommandBar renders with buttons collapsed into a menu 1`] = 
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1561,6 +1990,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1572,6 +2002,7 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1586,9 +2017,22 @@ exports[`DetailsViewCommandBar renders with export button and start over 1`] = `
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1655,6 +2099,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1666,6 +2111,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1680,9 +2126,22 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1748,6 +2207,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1759,6 +2219,7 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1773,9 +2234,22 @@ exports[`DetailsViewCommandBar renders without export button and without start o
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"
@@ -1862,6 +2336,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     />
     <mock-invalidloadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1873,6 +2348,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     />
     <mock-loadassessmentdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       featureflagstoredata="[object Object]"
       isopen="false"
@@ -1887,9 +2363,22 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
     />
     <mock-startoverdialog
       assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
       deps="[object Object]"
       dialogstate="none"
       featureflagstoredata="[object Object]"
+      narrowmodestatus="[object Object]"
+      rightpanelconfiguration="[object Object]"
+      scanmetadata="[object Object]"
+      switchernavconfiguration="[object Object]"
+      tabstoredata="[object Object]"
+    />
+    <mock-quickassesstoassessmentconfirmdialog
+      assessmentstoredata="[object Object]"
+      datatransferviewstoredata="[object Object]"
+      deps="[object Object]"
+      featureflagstoredata="[object Object]"
+      isshown="false"
       narrowmodestatus="[object Object]"
       rightpanelconfiguration="[object Object]"
       scanmetadata="[object Object]"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/quick-assess-to-assessment-dialog.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`QuickAssessToAssessmentDialog dialog is hidden when isShown is false 1`] = `
 <DocumentFragment>
   <mock-dialog
-    containerclassname="insightsDialogMainOverride"
     hidden="true"
+    modalprops="[object Object]"
     title="Continue to Assessment"
   >
     <div>
@@ -32,8 +32,8 @@ exports[`QuickAssessToAssessmentDialog dialog is hidden when isShown is false 1`
 exports[`QuickAssessToAssessmentDialog dialog is not hidden when isShown is true 1`] = `
 <DocumentFragment>
   <mock-dialog
-    containerclassname="insightsDialogMainOverride"
     hidden="false"
+    modalprops="[object Object]"
     title="Continue to Assessment"
   >
     <div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/transfer-to-assessment-button.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/transfer-to-assessment-button.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`TransferToAssessmentButton render 1`] = `
 exports[`TransferToAssessmentButton render: InsightsCommandButton props 1`] = `
 {
   "children": "Move to assessment",
+  "componentRef": undefined,
   "data-automation-id": "transfer-to-assessment-button",
   "iconProps": {
     "iconName": "fabricMoveToFolder",

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -55,7 +55,7 @@ import {
     getStartOverComponentForAssessment,
 } from 'DetailsView/components/start-over-component-factory';
 import { StartOverDialog } from 'DetailsView/components/start-over-dialog';
-import { TransferToAssessmentButtonProps } from 'DetailsView/components/transfer-to-assessment-button';
+import { TransferToAssessmentButtonProps, getTransferToAssessmentButton } from 'DetailsView/components/transfer-to-assessment-button';
 import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
 import { isNil } from 'lodash';
 import * as React from 'react';
@@ -70,6 +70,7 @@ import {
     useOriginalReactElements,
 } from 'tests/unit/mock-helpers/mock-module-helpers';
 import { IMock, It, Mock } from 'typemoq';
+import { QuickAssessToAssessmentDialog } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 
 jest.mock('DetailsView/components/report-export-button');
 jest.mock('DetailsView/components/load-assessment-dialog');
@@ -78,6 +79,7 @@ jest.mock('DetailsView/components/export-dialog');
 jest.mock('DetailsView/components/command-bar-buttons-menu');
 jest.mock('DetailsView/components/invalid-load-assessment-dialog');
 jest.mock('common/components/new-tab-link-with-tooltip');
+jest.mock('DetailsView/components/quick-assess-to-assessment-dialog');
 describe('DetailsViewCommandBar', () => {
     mockReactComponents([
         ReportExportButton,
@@ -86,7 +88,9 @@ describe('DetailsViewCommandBar', () => {
         CommandBarButtonsMenu,
         InvalidLoadAssessmentDialog,
         NewTabLinkWithTooltip,
+        ReportExportButton,
         ExportDialog,
+        QuickAssessToAssessmentDialog
     ]);
     const thePageTitle = 'command-bar-test-tab-title';
     const thePageUrl = 'command-bar-test-url';
@@ -205,9 +209,12 @@ describe('DetailsViewCommandBar', () => {
             _ => null,
         );
 
-        const actualSwitcherNavConfiguration = GetDetailsSwitcherNavConfiguration({
+        const actualSwitcherNavConfiguration = {
+            ...GetDetailsSwitcherNavConfiguration({
             selectedDetailsViewPivot: DetailsViewPivotType.assessment,
-        });
+            }),
+            TransferToAssessmentButton: getTransferToAssessmentButton
+        };
 
         const switcherNavConfiguration: DetailsViewSwitcherNavConfiguration = {
             CommandBar: switcherNavButtonOverrides?.includes('CommandBar')
@@ -267,6 +274,7 @@ describe('DetailsViewCommandBar', () => {
                 isCommandBarCollapsed,
             },
             rightPanelConfiguration,
+            dataTransferViewStoreData: { showQuickAssessToAssessmentConfirmDialog: false },
         } as DetailsViewCommandBarProps;
     }
 
@@ -374,6 +382,19 @@ describe('DetailsViewCommandBar', () => {
         expect(renderResult.asFragment()).toMatchSnapshot('start assessment over dialog open');
     });
 
+    test('renders transfer to assessment dialog', async () => {
+        const props = getProps();
+        setupTransferToAssessmentButtonFactory(props)
+        const renderResult = render(<DetailsViewCommandBar {...props} />);
+        expect(getMockComponentClassPropsForCall(QuickAssessToAssessmentDialog, 1).isShown).toBe(false)
+        expect(renderResult.asFragment()).toMatchSnapshot('transfer to assessment dialog hidden');
+        props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog = true;
+        setupTransferToAssessmentButtonFactory(props)
+        renderResult.rerender(<DetailsViewCommandBar {...props} />);
+        expect(getMockComponentClassPropsForCall(QuickAssessToAssessmentDialog, 2).isShown).toBe(true)
+        expect(renderResult.asFragment()).toMatchSnapshot('transfer to assessment dialog open');
+    });
+
     describe('Button focus', () => {
         beforeEach(() => {
             useOriginalReactElements('DetailsView/components/command-bar-buttons-menu', [
@@ -407,6 +428,40 @@ describe('DetailsViewCommandBar', () => {
             expect(textArea).toHaveFocus();
             getMockComponentCall(ExportDialog, 2)[0].afterDismissed();
             expect(exportButton).toHaveFocus();
+        });
+
+        test('do not change focus to transfer assessment button when focus ref is not set', async () => {
+            useOriginalReactElements('DetailsView/components/quick-assess-to-assessment-dialog', ['QuickAssessToAssessmentDialog']);
+            useOriginalReactElements
+            const props = getProps(['CommandBar']);
+            let setRef;
+            transferToAssessmentButtonFactoryMock.setup(m => m(It.isAny())).callback(props => {
+                setRef = props.buttonRef
+            })
+            const renderResult = render(<DetailsViewCommandBar {...props} />);
+            expect(setRef).toBeDefined()
+            expect(renderResult.baseElement).toHaveFocus();
+            setRef(undefined)
+            getMockComponentCall(QuickAssessToAssessmentDialog)[0].afterDialogDismissed();
+            expect(renderResult.baseElement).toHaveFocus();
+        });
+
+        test('focus transfer assessment button when focus ref is set', async () => {
+            useOriginalReactElements('DetailsView/components/quick-assess-to-assessment-dialog', ['QuickAssessToAssessmentDialog']);
+            const props = getProps(['TransferToAssessmentButton','CommandBar']);
+            const renderResult = render(<DetailsViewCommandBar {...props} />);
+            const transferButton = renderResult.getByRole('button', {
+                name: 'Move to assessment',
+            });
+            expect(transferButton).not.toHaveFocus();
+            getMockComponentCall(QuickAssessToAssessmentDialog)[0].afterDialogDismissed();
+            expect(transferButton).toHaveFocus();
+            props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog = true;
+            renderResult.rerender(<DetailsViewCommandBar {...props} />); //open the dialog
+            const continueButton = renderResult.getByRole('button', { name: 'Continue to Assessment' });
+            expect(continueButton).toHaveFocus();
+            getMockComponentCall(QuickAssessToAssessmentDialog, 1)[0].afterDialogDismissed();
+            expect(transferButton).toHaveFocus();
         });
 
         test('do not change focus to start over button when focus ref is not set', async () => {

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -44,6 +44,7 @@ import { InvalidLoadAssessmentDialog } from 'DetailsView/components/invalid-load
 import { LoadAssessmentDataValidator } from 'DetailsView/components/load-assessment-data-validator';
 import { LoadAssessmentDialog } from 'DetailsView/components/load-assessment-dialog';
 import { LoadAssessmentHelper } from 'DetailsView/components/load-assessment-helper';
+import { QuickAssessToAssessmentDialog } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 import { ReportExportButton } from 'DetailsView/components/report-export-button';
 import { ReportExportDialogFactoryProps } from 'DetailsView/components/report-export-dialog-factory';
 import {
@@ -55,7 +56,10 @@ import {
     getStartOverComponentForAssessment,
 } from 'DetailsView/components/start-over-component-factory';
 import { StartOverDialog } from 'DetailsView/components/start-over-dialog';
-import { TransferToAssessmentButtonProps, getTransferToAssessmentButton } from 'DetailsView/components/transfer-to-assessment-button';
+import {
+    TransferToAssessmentButtonProps,
+    getTransferToAssessmentButton,
+} from 'DetailsView/components/transfer-to-assessment-button';
 import { DataTransferViewController } from 'DetailsView/data-transfer-view-controller';
 import { isNil } from 'lodash';
 import * as React from 'react';
@@ -70,7 +74,6 @@ import {
     useOriginalReactElements,
 } from 'tests/unit/mock-helpers/mock-module-helpers';
 import { IMock, It, Mock } from 'typemoq';
-import { QuickAssessToAssessmentDialog } from 'DetailsView/components/quick-assess-to-assessment-dialog';
 
 jest.mock('DetailsView/components/report-export-button');
 jest.mock('DetailsView/components/load-assessment-dialog');
@@ -90,7 +93,7 @@ describe('DetailsViewCommandBar', () => {
         NewTabLinkWithTooltip,
         ReportExportButton,
         ExportDialog,
-        QuickAssessToAssessmentDialog
+        QuickAssessToAssessmentDialog,
     ]);
     const thePageTitle = 'command-bar-test-tab-title';
     const thePageUrl = 'command-bar-test-url';
@@ -211,9 +214,9 @@ describe('DetailsViewCommandBar', () => {
 
         const actualSwitcherNavConfiguration = {
             ...GetDetailsSwitcherNavConfiguration({
-            selectedDetailsViewPivot: DetailsViewPivotType.assessment,
+                selectedDetailsViewPivot: DetailsViewPivotType.assessment,
             }),
-            TransferToAssessmentButton: getTransferToAssessmentButton
+            TransferToAssessmentButton: getTransferToAssessmentButton,
         };
 
         const switcherNavConfiguration: DetailsViewSwitcherNavConfiguration = {
@@ -384,14 +387,18 @@ describe('DetailsViewCommandBar', () => {
 
     test('renders transfer to assessment dialog', async () => {
         const props = getProps();
-        setupTransferToAssessmentButtonFactory(props)
+        setupTransferToAssessmentButtonFactory(props);
         const renderResult = render(<DetailsViewCommandBar {...props} />);
-        expect(getMockComponentClassPropsForCall(QuickAssessToAssessmentDialog, 1).isShown).toBe(false)
+        expect(getMockComponentClassPropsForCall(QuickAssessToAssessmentDialog, 1).isShown).toBe(
+            false,
+        );
         expect(renderResult.asFragment()).toMatchSnapshot('transfer to assessment dialog hidden');
         props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog = true;
-        setupTransferToAssessmentButtonFactory(props)
+        setupTransferToAssessmentButtonFactory(props);
         renderResult.rerender(<DetailsViewCommandBar {...props} />);
-        expect(getMockComponentClassPropsForCall(QuickAssessToAssessmentDialog, 2).isShown).toBe(true)
+        expect(getMockComponentClassPropsForCall(QuickAssessToAssessmentDialog, 2).isShown).toBe(
+            true,
+        );
         expect(renderResult.asFragment()).toMatchSnapshot('transfer to assessment dialog open');
     });
 
@@ -431,24 +438,30 @@ describe('DetailsViewCommandBar', () => {
         });
 
         test('do not change focus to transfer assessment button when focus ref is not set', async () => {
-            useOriginalReactElements('DetailsView/components/quick-assess-to-assessment-dialog', ['QuickAssessToAssessmentDialog']);
-            useOriginalReactElements
+            useOriginalReactElements('DetailsView/components/quick-assess-to-assessment-dialog', [
+                'QuickAssessToAssessmentDialog',
+            ]);
+            useOriginalReactElements;
             const props = getProps(['CommandBar']);
             let setRef;
-            transferToAssessmentButtonFactoryMock.setup(m => m(It.isAny())).callback(props => {
-                setRef = props.buttonRef
-            })
+            transferToAssessmentButtonFactoryMock
+                .setup(m => m(It.isAny()))
+                .callback(props => {
+                    setRef = props.buttonRef;
+                });
             const renderResult = render(<DetailsViewCommandBar {...props} />);
-            expect(setRef).toBeDefined()
+            expect(setRef).toBeDefined();
             expect(renderResult.baseElement).toHaveFocus();
-            setRef(undefined)
+            setRef(undefined);
             getMockComponentCall(QuickAssessToAssessmentDialog)[0].afterDialogDismissed();
             expect(renderResult.baseElement).toHaveFocus();
         });
 
         test('focus transfer assessment button when focus ref is set', async () => {
-            useOriginalReactElements('DetailsView/components/quick-assess-to-assessment-dialog', ['QuickAssessToAssessmentDialog']);
-            const props = getProps(['TransferToAssessmentButton','CommandBar']);
+            useOriginalReactElements('DetailsView/components/quick-assess-to-assessment-dialog', [
+                'QuickAssessToAssessmentDialog',
+            ]);
+            const props = getProps(['TransferToAssessmentButton', 'CommandBar']);
             const renderResult = render(<DetailsViewCommandBar {...props} />);
             const transferButton = renderResult.getByRole('button', {
                 name: 'Move to assessment',
@@ -458,7 +471,9 @@ describe('DetailsViewCommandBar', () => {
             expect(transferButton).toHaveFocus();
             props.dataTransferViewStoreData.showQuickAssessToAssessmentConfirmDialog = true;
             renderResult.rerender(<DetailsViewCommandBar {...props} />); //open the dialog
-            const continueButton = renderResult.getByRole('button', { name: 'Continue to Assessment' });
+            const continueButton = renderResult.getByRole('button', {
+                name: 'Continue to Assessment',
+            });
             expect(continueButton).toHaveFocus();
             getMockComponentCall(QuickAssessToAssessmentDialog, 1)[0].afterDialogDismissed();
             expect(transferButton).toHaveFocus();

--- a/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/quick-assess-to-assessment-dialog.test.tsx
@@ -24,15 +24,19 @@ describe('QuickAssessToAssessmentDialog', () => {
     let dataTransferViewControllerMock: IMock<DataTransferViewController>;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
     let props: QuickAssessToAssessmentDialogProps;
+    let afterDialogDismissedMock: IMock<() => void>;
 
     beforeEach(() => {
         dataTransferViewControllerMock = Mock.ofType(DataTransferViewController);
         detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
+        afterDialogDismissedMock = Mock.ofInstance(() => null);
+
         props = {
             deps: {
                 detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
                 dataTransferViewController: dataTransferViewControllerMock.object,
             },
+            afterDialogDismissed: afterDialogDismissedMock.object,
         } as QuickAssessToAssessmentDialogProps;
     });
 
@@ -83,5 +87,11 @@ describe('QuickAssessToAssessmentDialog', () => {
             m => m.hideQuickAssessToAssessmentConfirmDialog(),
             Times.once(),
         );
+    });
+
+    test('on dialog dismissed: call afterDialogDismissed', () => {
+        render(<QuickAssessToAssessmentDialog {...props} />);
+        getMockComponentClassPropsForCall(Dialog).modalProps.onDismissed();
+        afterDialogDismissedMock.verify(m => m(), Times.once());
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/should-show-report-export-button.test.ts
@@ -53,6 +53,7 @@ describe('ShouldShowReportExportButton', () => {
             tabStopRequirementData: null,
             userConfigurationStoreData,
             featureFlagStoreData: null,
+            dataTransferViewStoreData: null,
         } as DetailsViewCommandBarProps;
     }
 

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -146,7 +146,6 @@ describe('DetailsViewBody', () => {
             expect(renderResult.asFragment()).toMatchSnapshot();
             expectMockedComponentPropsToMatchSnapshots([
                 FluentSideNav,
-                QuickAssessToAssessmentDialog,
                 QuickAssessCommandBar,
                 TargetPageHiddenBar,
             ]);


### PR DESCRIPTION
#### Details

This PR fixes two accessibility bugs:
* `QuickAssessToAssessmentDialog` does not redirect focus to the trigger button after it closes
  * [before video](https://www.loom.com/share/6c19f10e23044a3a97064d79029b5e30)
  * [after video](https://www.loom.com/share/3b1799677d114a80ab54deb140b0e5d6)
* Failure instance visual helper checkbox in issues table does not correctly update `aria-checked`/`checked` when it is toggled
  * [before video](https://www.loom.com/share/9ecd18aca30a44dc86697bea37238fde)
  * [after video](https://www.loom.com/share/02fdc17ca946461fb2d119c8de759150)

##### Motivation

Accessibility Compliance

##### Context

For the dialog close focus bug, I moved the `QuickAssessToAssessmentDialog` to be inside the `DetailsViewCommandBar` like the other buttons that open dialogs. I managed focus the same way we do for the `ReportExportDialog`. 

For the visual helper checkbox bug, we were only setting `aria-checked` and not `checked` on the checkbox, so now we explicitly set the `checked` attribute (which in turn updates `aria-checked`).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [N/A] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
