### PR TITLE
fix: mocked date for command Bar unit test case

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -314,6 +314,10 @@ describe('DetailsViewCommandBar', () => {
     });
 
     test('renders report export dialog', async () => {
+        const originalDate = Date;
+        const mockDate = new Date('2024-03-07T12:00:00Z');
+        global.Date = jest.fn(() => mockDate) as unknown as typeof Date;
+        global.Date.now = jest.fn(() => mockDate.getTime()) as unknown as typeof Date.now;
         const props = getProps();
         useOriginalReactElements('DetailsView/components/report-export-button', [
             'ReportExportButton',
@@ -325,6 +329,7 @@ describe('DetailsViewCommandBar', () => {
         await userEvent.click(exportButton);
         expect(getMockComponentClassPropsForCall(ExportDialog, 2).isOpen).toBe(true);
         expect(renderResult.asFragment()).toMatchSnapshot('export dialog open');
+        global.Date = originalDate;
     });
 
     test('renders load assessment dialog', async () => {


### PR DESCRIPTION
#### Details

Unit test case for details-view-command-bar.test is failing due to mismatched dates between saved snapshot and rendered object. Rendered object always takes the current date. Mocked the date in the test case to return specific date instead of current date.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
