### PR TITLE
chore: Typescript Cleanup Part 2 of 3 for deps:null, pageTitle, requirement, titleSize="title & defaultViewport: null

### DIFF
--- a/src/reports/components/report-sections/combined-report-rules-only-sections.tsx
+++ b/src/reports/components/report-sections/combined-report-rules-only-sections.tsx
@@ -34,7 +34,6 @@ const makeCombinedReportRulesOnlySection = (options: {
                         outcomeCount={cardRuleResults.length}
                         outcomeType={outcomeType}
                         title={title}
-                        titleSize="title"
                     />
                 ),
                 content: (

--- a/src/reports/components/report-sections/report-collapsible-container.tsx
+++ b/src/reports/components/report-sections/report-collapsible-container.tsx
@@ -4,6 +4,7 @@ import { css } from '@fluentui/utilities';
 import { HeadingElementForLevel, HeadingLevel } from 'common/components/heading-element-for-level';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
+import { CollapsibleResultSectionDeps } from './collapsible-result-section';
 
 export interface ReportCollapsibleContainerProps {
     id: string;
@@ -14,6 +15,8 @@ export interface ReportCollapsibleContainerProps {
     containerClassName?: string;
     buttonAriaLabel?: string;
     testKey?: string;
+    deps: CollapsibleResultSectionDeps;
+    onExpandToggle: (event: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const ReportCollapsibleContainer = NamedFC<ReportCollapsibleContainerProps>(

--- a/src/tests/end-to-end/common/browser-factory.ts
+++ b/src/tests/end-to-end/common/browser-factory.ts
@@ -131,7 +131,6 @@ async function launchNewBrowserContext(
         // Headless doesn't support extensions
         // see https://playwright.dev/#version=v1.2.0&path=docs%2Fapi.md&q=working-with-chrome-extensions
         headless: false,
-        defaultViewport: null,
         args: [
             // We use the smallest size we support both because we want to ensure functionality works there
             // and also because it improves test runtime to render fewer pixels, especially in environments

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -6,6 +6,8 @@ import { Requirement } from 'assessments/types/requirement';
 import {
     AddFailureInstancePayload,
     AddResultDescriptionPayload,
+    AssessmentActionInstancePayload,
+    AssessmentToggleActionPayload,
     ChangeInstanceSelectionPayload,
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
@@ -1548,7 +1550,7 @@ describe('AssessmentStore', () => {
 
         const initialState = getStateWithAssessment(assessmentData);
 
-        const payload: ToggleActionPayload = {
+        const payload: AssessmentActionInstancePayload = {
             test: assessmentType,
             requirement: requirementKey,
             selector: 'selector',
@@ -1926,7 +1928,7 @@ describe('AssessmentStore', () => {
 
         const initialState = getStateWithAssessment(assessmentData);
 
-        const payload: ToggleActionPayload = {
+        const payload: AssessmentToggleActionPayload = {
             test: assessmentType,
             requirement: requirementKey,
         };

--- a/src/tests/unit/tests/reports/components/fast-pass-report-automated-checks-results.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report-automated-checks-results.test.tsx
@@ -24,8 +24,6 @@ describe('FastPassReportSummary', () => {
     mockReactComponents([FailedInstancesSection, IncompleteChecksSection, PassedChecksSection]);
     let props: FastPassReportAutomatedChecksResultsProps;
     beforeEach(() => {
-        const pageTitle = 'page-title';
-        const pageUrl = 'url:target-page';
         const scanDate = new Date(Date.UTC(0, 1, 2, 3));
         const getScriptStub = () => '';
         const getGuidanceTagsStub = () => [];
@@ -47,19 +45,7 @@ describe('FastPassReportSummary', () => {
             deps: {} as FastPassReportDeps,
             fixInstructionProcessor: fixInstructionProcessorMock.object,
             recommendColor: recommendColorMock.object,
-            pageTitle,
-            pageUrl,
             description: 'test description',
-            toolData,
-            scanResult: {
-                passes: [],
-                violations: [],
-                inapplicable: [],
-                incomplete: [],
-                timestamp: 'today',
-                targetPageTitle: pageTitle,
-                targetPageUrl: pageUrl,
-            },
             toUtcString: () => '',
             getCollapsibleScript: getScriptStub,
             getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
@@ -71,8 +57,6 @@ describe('FastPassReportSummary', () => {
                 },
                 tabStops: null, // Should be filled in as part of #1897876
             },
-            userConfigurationStoreData: null,
-            targetAppInfo,
             shouldAlertFailuresCount: false,
             scanMetadata: {
                 toolData,

--- a/src/tests/unit/tests/reports/components/fast-pass-report.test.tsx
+++ b/src/tests/unit/tests/reports/components/fast-pass-report.test.tsx
@@ -61,8 +61,6 @@ describe(FastPassReport.displayName, () => {
         FooterText,
     ]);
     it('renders', () => {
-        const pageTitle = 'page-title';
-        const pageUrl = 'url:target-page';
         const scanDate = new Date(Date.UTC(0, 1, 2, 3));
         const getScriptStub = () => '';
         const getGuidanceTagsStub = () => [];
@@ -85,19 +83,7 @@ describe(FastPassReport.displayName, () => {
             deps: {} as FastPassReportDeps,
             fixInstructionProcessor: fixInstructionProcessorMock.object,
             recommendColor: recommendColorMock.object,
-            pageTitle,
-            pageUrl,
             description: 'test description',
-            toolData,
-            scanResult: {
-                passes: [],
-                violations: [],
-                inapplicable: [],
-                incomplete: [],
-                timestamp: 'today',
-                targetPageTitle: pageTitle,
-                targetPageUrl: pageUrl,
-            },
             toUtcString: () => '',
             getCollapsibleScript: getScriptStub,
             getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
@@ -120,8 +106,6 @@ describe(FastPassReport.displayName, () => {
                     },
                 },
             },
-            userConfigurationStoreData: null,
-            targetAppInfo,
             shouldAlertFailuresCount: false,
             scanMetadata: {
                 toolData,


### PR DESCRIPTION
#### Details

Typescript Cleanup Part 2 of 3 
We have total 140 errors in 104 files. Thus, targeting each error and fixing it. 

##### Motivation

Errors observed in below files observed after removing deprecated properties from tsconfig file:
1.**deps: null**  
src/reports/components/report-sections/collapsible-result-section.tsx (1) 
src/reports/components/report-sections/collapsible-url-result-section.tsx (1) 

2.**titleSize="title"**  
src/reports/components/report-sections/combined-report-rules-only-sections.tsx (1) 

3.**defaultViewport: null**  
src/tests/end-to-end/common/browser-factory.ts (1) 

4.**requirement: requirementKey**  
src/tests/unit/tests/background/stores/assessment-store.test.ts (2) 

5.**pageTitle**  
src/tests/unit/tests/reports/components/fast-pass-report-automated-checks-results.test.tsx (1) 
src/tests/unit/tests/reports/components/fast-pass-report.test.tsx (1) 


Thus, total number of errors covered as part of this user story: **8**


##### Context

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #(https://github.com/microsoft/accessibility-insights-web/pull/6611)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
