### PR TITLE
fix: Added setting to skip tags for e2e-reliability pipeline

### DIFF
--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -33,6 +33,8 @@ extends:
             name: $(a11yInsightsPool) # Name of your hosted pool
             image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used
             os: windows
+        settings:
+            skipBuildTagsForGitHubPullRequests: true
         sdl:
             codeql:
                 compiled:


### PR DESCRIPTION
#### Details

1ES PT adds tags to pipeline runs using the access token provided by ADO. In the case of pipeline runs against forked repos of a GitHub repo, the access token does not have Edit build quality permissions and hence cannot add tags. To unblock those pipelines, skipped tagging by using the option SkipBuildTagsForGitHubPullRequests. This is similar change which we did earlier for other pipelines like https://github.com/microsoft/accessibility-insights-docs/pull/1921

Verified that the only change in the pipeline run is that it do not add "1ES.PT.Unofficial" tag on the Run. In place of that it adds below warning message.

##[warning]1ES PT Warning: Skipping build tags as this build is a pull request form GitHub which does not have permissions to add tags.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
