### PR TITLE
fix: Changing ubuntu image for CI pipeline to match the image used in github PR workflow

### DIFF
--- a/build-webCI.yaml
+++ b/build-webCI.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2022-secure'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-22.04-secure'
+    linuxImage: 'ubuntu-20.04'
     Codeql.Enabled: true
 
 extends:

--- a/build.yaml
+++ b/build.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2022-secure'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-22.04-secure'
+    linuxImage: 'ubuntu-20.04'
     Codeql.Enabled: true
 
 extends:


### PR DESCRIPTION
CI pipeline is failing frequently with transient timeout issues in e2e testing. GitHub PR workflow does not fail for the same step. So updating Linux image to ubuntu 20.04 in CI to match image version in GitHub PR workflow.

#### Details

<!-- Usually a sentence or two describing what the PR changes -->

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
