### PR TITLE
feat(target-size-automation): adding target size to the needs-review rules

### DIFF
--- a/src/scanner/get-rule-inclusions.ts
+++ b/src/scanner/get-rule-inclusions.ts
@@ -61,6 +61,7 @@ export const needsReviewRules = [
     'th-has-data-cells',
     'label-content-name-mismatch',
     'p-as-heading',
+    'target-size',
 ];
 
 export const getNeedsReviewRulesConfig: () => DictionaryStringTo<RuleIncluded> = () => {


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Adding `target-size` to the needs review rules. This is the pre-PR for Madalyn's PR that enables `target-size` in assessment and provides the initial visualization and support for the test step

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The enablement of `target-size` for general assessment

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
