### PR TITLE
fix: ad-hoc visualization state becomes inconsistent after toggling extension off and on

### DIFF
--- a/src/background/initial-visualization-store-data-generator.ts
+++ b/src/background/initial-visualization-store-data-generator.ts
@@ -56,9 +56,10 @@ export class InitialVisualizationStoreDataGenerator {
         };
 
         const initialState = !isEmpty(persistedData)
-            ? merge({}, defaultValues, persistedData)
+            ? merge({}, defaultValues, persistedData, {
+                  tests: { adhoc: defaultValues.tests.adhoc },
+              })
             : defaultValues;
-
         return initialState;
     }
 


### PR DESCRIPTION
#### Details

This PR adjusts the logic for setting extension initial state so that the toggles are always off (reflecting reality because the visualizations will never be active on extension start).

##### Motivation

Addresses #6256

##### Context


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #6256
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
