### PR TITLE
fix: skip codecov publish report step in ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,34 +79,6 @@ jobs:
           test-results/unit/coverage/cobertura-coverage.xml
       timeout-minutes: 5
 
-  # publish-code-coverage:
-  #   needs: unit-tests # This waits for *all* of the unit-tests jobs
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #   # This only needs to be present so codecov can use the source tree for some post-processing
-  #   # This job doesn't require that we install dependencies
-  #   - uses: actions/checkout@v4.1.7
-  #     timeout-minutes: 2
-
-  #   - uses: actions/setup-node@v4
-  #     with: { node-version: "${{ env.NODE_VERSION }}" }
-  #     timeout-minutes: 2
-
-  #   - uses: actions/download-artifact@v4
-  #     with:
-  #       name: unit-tests-1-results
-  #       path: unit-tests-1-results
-  #     timeout-minutes: 2
-
-  #   - uses: actions/download-artifact@v4
-  #     with:
-  #       name: unit-tests-2-results
-  #       path: unit-tests-2-results
-  #     timeout-minutes: 2
-
-  #   - run: npx codecov
-  #     timeout-minutes: 3
-
   lints:
     runs-on: ubuntu-20.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,34 +79,33 @@ jobs:
           test-results/unit/coverage/cobertura-coverage.xml
       timeout-minutes: 5
 
-  publish-code-coverage:
-    if: false
-    needs: unit-tests # This waits for *all* of the unit-tests jobs
-    runs-on: ubuntu-20.04
-    steps:
-    # This only needs to be present so codecov can use the source tree for some post-processing
-    # This job doesn't require that we install dependencies
-    - uses: actions/checkout@v4.1.7
-      timeout-minutes: 2
+  # publish-code-coverage:
+  #   needs: unit-tests # This waits for *all* of the unit-tests jobs
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #   # This only needs to be present so codecov can use the source tree for some post-processing
+  #   # This job doesn't require that we install dependencies
+  #   - uses: actions/checkout@v4.1.7
+  #     timeout-minutes: 2
 
-    - uses: actions/setup-node@v4
-      with: { node-version: "${{ env.NODE_VERSION }}" }
-      timeout-minutes: 2
+  #   - uses: actions/setup-node@v4
+  #     with: { node-version: "${{ env.NODE_VERSION }}" }
+  #     timeout-minutes: 2
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: unit-tests-1-results
-        path: unit-tests-1-results
-      timeout-minutes: 2
+  #   - uses: actions/download-artifact@v4
+  #     with:
+  #       name: unit-tests-1-results
+  #       path: unit-tests-1-results
+  #     timeout-minutes: 2
 
-    - uses: actions/download-artifact@v4
-      with:
-        name: unit-tests-2-results
-        path: unit-tests-2-results
-      timeout-minutes: 2
+  #   - uses: actions/download-artifact@v4
+  #     with:
+  #       name: unit-tests-2-results
+  #       path: unit-tests-2-results
+  #     timeout-minutes: 2
 
-    - run: npx codecov
-      timeout-minutes: 3
+  #   - run: npx codecov
+  #     timeout-minutes: 3
 
   lints:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
   publish-code-coverage:
     needs: unit-tests # This waits for *all* of the unit-tests jobs
     runs-on: ubuntu-20.04
-    enable: false
     steps:
     # This only needs to be present so codecov can use the source tree for some post-processing
     # This job doesn't require that we install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
   publish-code-coverage:
     needs: unit-tests # This waits for *all* of the unit-tests jobs
     runs-on: ubuntu-20.04
+    enable: false
     steps:
     # This only needs to be present so codecov can use the source tree for some post-processing
     # This job doesn't require that we install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
       timeout-minutes: 5
 
   publish-code-coverage:
+    if: false
     needs: unit-tests # This waits for *all* of the unit-tests jobs
     runs-on: ubuntu-20.04
     steps:

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -78,21 +78,21 @@ extends:
                           displayName: publish test results
                           timeoutInMinutes: 3
 
-                        - task: PublishCodeCoverageResults@1
-                          inputs:
-                              codeCoverageTool: Cobertura
-                              summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
-                              failIfCoverageEmpty: true
-                              # We care most about the summary information; adding the detailed files doesn't give enough extra information
-                              # to be worth the 1min it adds to the build.
-                              # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
-                              # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
-                          displayName: publish code coverage
-                          timeoutInMinutes: 5
+                        # - task: PublishCodeCoverageResults@1
+                        #   inputs:
+                        #       codeCoverageTool: Cobertura
+                        #       summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
+                        #       failIfCoverageEmpty: true
+                        #       # We care most about the summary information; adding the detailed files doesn't give enough extra information
+                        #       # to be worth the 1min it adds to the build.
+                        #       # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
+                        #       # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
+                        #   displayName: publish code coverage
+                        #   timeoutInMinutes: 5
 
-                        - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
-                          displayName: Publish code coverage to codecov
-                          timeoutInMinutes: 3
+                        # - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
+                        #   displayName: Publish code coverage to codecov
+                        #   timeoutInMinutes: 3
 
                   - job: 'publish_build_drops'
                     templateContext:

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -83,7 +83,6 @@ extends:
                               codeCoverageTool: Cobertura
                               summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
                               failIfCoverageEmpty: true
-                              enable: false
                               # We care most about the summary information; adding the detailed files doesn't give enough extra information
                               # to be worth the 1min it adds to the build.
                               # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -78,17 +78,17 @@ extends:
                           displayName: publish test results
                           timeoutInMinutes: 3
 
-                        # - task: PublishCodeCoverageResults@1
-                        #   inputs:
-                        #       codeCoverageTool: Cobertura
-                        #       summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
-                        #       failIfCoverageEmpty: true
-                        #       # We care most about the summary information; adding the detailed files doesn't give enough extra information
-                        #       # to be worth the 1min it adds to the build.
-                        #       # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
-                        #       # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
-                        #   displayName: publish code coverage
-                        #   timeoutInMinutes: 5
+                        - task: PublishCodeCoverageResults@1
+                          inputs:
+                              codeCoverageTool: Cobertura
+                              summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
+                              failIfCoverageEmpty: true
+                              # We care most about the summary information; adding the detailed files doesn't give enough extra information
+                              # to be worth the 1min it adds to the build.
+                              # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
+                              # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
+                          displayName: publish code coverage
+                          timeoutInMinutes: 5
 
                         # - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
                         #   displayName: Publish code coverage to codecov

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -83,6 +83,7 @@ extends:
                               codeCoverageTool: Cobertura
                               summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
                               failIfCoverageEmpty: true
+                              enable: false
                               # We care most about the summary information; adding the detailed files doesn't give enough extra information
                               # to be worth the 1min it adds to the build.
                               # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -87,6 +87,7 @@ extends:
                               # to be worth the 1min it adds to the build.
                               # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
                               # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
+                          enabled: false
                           displayName: publish code coverage
                           timeoutInMinutes: 5
 

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -87,7 +87,6 @@ extends:
                               # to be worth the 1min it adds to the build.
                               # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
                               # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
-                          enabled: false
                           displayName: publish code coverage
                           timeoutInMinutes: 5
 

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -90,10 +90,6 @@ extends:
                           displayName: publish code coverage
                           timeoutInMinutes: 5
 
-                        # - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
-                        #   displayName: Publish code coverage to codecov
-                        #   timeoutInMinutes: 3
-
                   - job: 'publish_build_drops'
                     templateContext:
                         outputs:


### PR DESCRIPTION
#### Details

Skip codecoverage step in pipeline as codecov package is deprecated.


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
