### PR TITLE
fix: Left nav lacks clear tab or focus indicators with Windows HC modes

### DIFF
--- a/src/DetailsView/components/base-left-nav.scss
+++ b/src/DetailsView/components/base-left-nav.scss
@@ -23,6 +23,10 @@
                 a,
                 button {
                     background-color: $nav-link-selected !important;
+                    @media (forced-colors: active) {
+                        forced-color-adjust: none;
+                        background-color: Highlight !important;
+                    }
                 }
             }
 
@@ -36,6 +40,9 @@
             a,
             button {
                 background-color: $nav-link-hover;
+                @media (forced-colors: active) {
+                    background-color: Highlight !important;
+                }
             }
         }
     }

--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -38,6 +38,10 @@
     text-overflow: ellipsis;
     display: inline-block;
     overflow: hidden;
+
+    &:hover {
+        text-decoration: underline;
+    }
 }
 
 .target-page-link {

--- a/src/DetailsView/components/left-nav/common-left-nav-link.scss
+++ b/src/DetailsView/components/left-nav/common-left-nav-link.scss
@@ -17,7 +17,19 @@
         color: $always-black;
     }
 
-    .link-icon {
-        font-size: 24px;
+    @media (forced-colors: active) {
+        :global(.is-selected) & {
+            forced-color-adjust: none;
+            color: HighlightText;
+        }
+
+        :global(.ms-Nav-compositeLink):hover & {
+            forced-color-adjust: none;
+            color: HighlightText !important;
+        }
+
+        .link-icon {
+            font-size: 24px;
+        }
     }
 }

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -13,10 +13,6 @@
     height: calc(100vh - (#{$details-view-header-bar-height}));
 
     :global {
-        .left-nav-icon {
-            color: $neutral-60;
-        }
-
         .ms-Nav-groupContent {
             margin-bottom: 0;
         }
@@ -48,7 +44,6 @@
         }
 
         .overview-percent {
-            color: $neutral-55;
             line-height: 16px;
             font-size: 12px;
         }
@@ -64,10 +59,6 @@
                 border-bottom: 0;
             }
 
-            .ms-Button-label {
-                color: $neutral-100;
-            }
-
             &.is-selected {
                 .ms-Button-label {
                     color: $always-black;
@@ -80,10 +71,19 @@
                     .ms-Button-label,
                     .overview-percent {
                         color: $highlighted-text;
+
+                        @media (forced-colors: active) {
+                            forced-color-adjust: none;
+                            color: HighlightText !important;
+                        }
                     }
 
                     .left-nav-icon {
                         color: $left-nav-icon;
+                        @media (forced-colors: active) {
+                            forced-color-adjust: none;
+                            color: HighlightText !important;
+                        }
                     }
                 }
 

--- a/src/DetailsView/components/left-nav/left-nav-icon.scss
+++ b/src/DetailsView/components/left-nav/left-nav-icon.scss
@@ -21,4 +21,15 @@
         background: $index-circle-background;
         border-color: $neutral-0;
     }
+
+    @media (forced-colors: active) {
+        li :global(.is-expanded) &,
+        :global(.ms-Nav-compositeLink):hover &,
+        :global(.ms-Nav-compositeLink.is-selected) & {
+            forced-color-adjust: none;
+            background-color: ButtonFace !important;
+            color: ButtonText !important;
+            border-color: ButtonText !important;
+        }
+    }
 }

--- a/src/DetailsView/components/requirement-context-section.scss
+++ b/src/DetailsView/components/requirement-context-section.scss
@@ -46,13 +46,15 @@
 
         &:hover {
             color: $link-hover;
+            text-decoration: underline;
         }
 
         @media screen and (forced-colors: active) {
             color: linktext;
 
             &:hover {
-                color: linktext;
+                color: ButtonText !important;
+                text-decoration: underline;
             }
         }
     }

--- a/src/common/components/new-tab-link-with-tooltip.scss
+++ b/src/common/components/new-tab-link-with-tooltip.scss
@@ -20,6 +20,23 @@
 
     &:hover,
     &:active {
+        text-decoration: underline !important;
+    }
+}
+
+.insights-link-icon {
+    display: flex;
+
+    &:hover,
+    &:active {
         text-decoration: none !important;
+    }
+}
+
+@media screen and (forced-colors: active) {
+    .insights-link:hover,
+    .insights-link-icon:hover {
+        forced-color-adjust: none;
+        color: ButtonText !important;
     }
 }

--- a/src/common/components/new-tab-link-with-tooltip.tsx
+++ b/src/common/components/new-tab-link-with-tooltip.tsx
@@ -6,12 +6,15 @@ import * as React from 'react';
 import { NamedFC } from '../react/named-fc';
 import styles from './new-tab-link-with-tooltip.scss';
 
-export type NewTabLinkWithTooltipProps = ILinkProps & { tooltipContent: string | undefined };
+export type NewTabLinkWithTooltipProps = ILinkProps & {
+    tooltipContent: string | undefined;
+    className?: string | undefined;
+};
 
 export const NewTabLinkWithTooltip = NamedFC<NewTabLinkWithTooltipProps>(
     'NewTabLinkWithTooltip',
     props => {
-        const { tooltipContent, ...linkProps } = props;
+        const { tooltipContent, className, ...linkProps } = props;
         const hostStyles: Partial<ITooltipHostStyles> = {
             root: styles.insightsTooltipHost,
         };
@@ -23,7 +26,7 @@ export const NewTabLinkWithTooltip = NamedFC<NewTabLinkWithTooltipProps>(
         };
         return (
             <TooltipHost content={tooltipContent} styles={hostStyles} calloutProps={calloutProps}>
-                <NewTabLink className={styles.insightsLink} {...linkProps} />
+                <NewTabLink className={className ?? styles.insightsLink} {...linkProps} />
             </TooltipHost>
         );
     },

--- a/src/tests/unit/tests/views/content/__snapshots__/content-link.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-link.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ContentLink renders from content, only have the icon 1`] = `
 <DocumentFragment>
   <mock-newtablinkwithtooltip
     aria-label="Guidance"
+    classname="insightsLinkIcon"
     href="/insights.html#/content/for/testing"
     tooltipcontent="Guidance"
   >
@@ -20,6 +21,7 @@ exports[`ContentLink renders from path, only have the icon 1`] = `
 <DocumentFragment>
   <mock-newtablinkwithtooltip
     aria-label="Guidance"
+    classname="insightsLinkIcon"
     href="/insights.html#/content/for/testing"
     tooltipcontent="Guidance"
   >
@@ -34,6 +36,7 @@ exports[`ContentLink renders with both text and icon 1`] = `
 <DocumentFragment>
   <mock-newtablinkwithtooltip
     aria-label="test guidance"
+    classname="insightsLinkIcon"
     href="/insights.html#/content/for/testing"
     tooltipcontent="Guidance"
   >
@@ -49,6 +52,7 @@ exports[`ContentLink renders with only text 1`] = `
 <DocumentFragment>
   <mock-newtablinkwithtooltip
     aria-label="test guidance"
+    classname="insightsLinkIcon"
     href="/insights.html#/content/for/testing"
     tooltipcontent="Guidance"
   >

--- a/src/views/content/content-link.tsx
+++ b/src/views/content/content-link.tsx
@@ -3,6 +3,7 @@
 import { Icon } from '@fluentui/react';
 import { NewTabLink } from 'common/components/new-tab-link';
 import { NewTabLinkWithTooltip } from 'common/components/new-tab-link-with-tooltip';
+import styles from 'common/components/new-tab-link-with-tooltip.scss';
 import * as React from 'react';
 
 import { ContentActionMessageCreator } from '../../common/message-creators/content-action-message-creator';
@@ -52,6 +53,7 @@ export const ContentLink = NamedFC<ContentLinkProps>(
                 onClick={handleLinkClick}
                 tooltipContent={'Guidance'}
                 aria-label={ariaLabel}
+                className={styles.insightsLinkIcon}
             >
                 {icon}
                 {linkText}


### PR DESCRIPTION
#### Details

Fixed the Color contrast issue of focus for left nav tab for high contrast theme.
Added underlines for links as per the requirement.

##### Motivation

Addresses Issue - https://github.com/microsoft/accessibility-insights-web/issues/4263

##### Context

Added focus indicators/clear tab on left nav. Screenshots added for reference-

Theme - Desert
![image](https://github.com/user-attachments/assets/148e23e3-dde7-4d86-b82b-a7ae31c62df8)

Theme - Aquatic
![image](https://github.com/user-attachments/assets/7c57d410-2439-4f8d-a20b-f9524a1bb6d0)

Theme - Dusk
![image](https://github.com/user-attachments/assets/4bd94a59-6a56-48df-9935-92ce3bbe1c4e)

Theme - Night Sky
![image](https://github.com/user-attachments/assets/38c45f5a-b46c-41cf-8625-78d2014a136c)

Screenshots of added underlines upon hover are pasted as below-

Theme - None
![image](https://github.com/user-attachments/assets/453cee17-6602-43d8-972e-70cc08b8f6f6)

Theme - Aquatic
![image](https://github.com/user-attachments/assets/837fd9b2-294e-4ebe-9845-b2541c50d07c)

Theme - Desert
![image](https://github.com/user-attachments/assets/f12df5ca-c7f7-4b99-aa59-21708512771d)

Theme - Dusk
![image](https://github.com/user-attachments/assets/738a07d1-b320-441b-8804-2ccc30ff4bf9)

Theme - Night Sky
![image](https://github.com/user-attachments/assets/76ae23a9-c9eb-482f-b576-4ec4cd06530c)



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #4263 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

##### Reference PR
https://github.com/microsoft/accessibility-insights-web/pull/7311




