### PR TITLE
fix: changing ubuntu and macOS image to Latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
     - uses: actions/checkout@v4.2.2
@@ -44,7 +44,7 @@ jobs:
     
   unit-tests:
     name: unit-tests (${{ matrix.shard-index }}/${{ strategy.job-total }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     strategy:
       fail-fast: false
@@ -80,7 +80,7 @@ jobs:
       timeout-minutes: 5
 
   lints:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
     - uses: actions/checkout@v4.2.2
@@ -115,7 +115,7 @@ jobs:
       timeout-minutes: 6
 
   codeql:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.2.2
       timeout-minutes: 2
@@ -131,7 +131,7 @@ jobs:
 
   e2e-web-tests:
     name: e2e-web-tests (${{ matrix.shard-index }}/${{ strategy.job-total }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # We need to update this each time we update playwright
     container: mcr.microsoft.com/playwright:v1.48.2-focal
     strategy:
@@ -187,7 +187,7 @@ jobs:
       timeout-minutes: 15 # chrome-logs is several GB, this can take a while
 
   e2e-report-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
     - uses: actions/checkout@v4.2.2
@@ -217,7 +217,7 @@ jobs:
       timeout-minutes: 3
 
   check-clearly-defined:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.2.2
       timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
     - uses: actions/checkout@v4.2.2
@@ -44,7 +44,7 @@ jobs:
     
   unit-tests:
     name: unit-tests (${{ matrix.shard-index }}/${{ strategy.job-total }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     strategy:
       fail-fast: false
@@ -80,7 +80,7 @@ jobs:
       timeout-minutes: 5
 
   lints:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
     - uses: actions/checkout@v4.2.2
@@ -115,7 +115,7 @@ jobs:
       timeout-minutes: 6
 
   codeql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4.2.2
       timeout-minutes: 2
@@ -131,7 +131,7 @@ jobs:
 
   e2e-web-tests:
     name: e2e-web-tests (${{ matrix.shard-index }}/${{ strategy.job-total }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # We need to update this each time we update playwright
     container: mcr.microsoft.com/playwright:v1.48.2-focal
     strategy:
@@ -187,7 +187,7 @@ jobs:
       timeout-minutes: 15 # chrome-logs is several GB, this can take a while
 
   e2e-report-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1 }
     steps:
     - uses: actions/checkout@v4.2.2
@@ -217,7 +217,7 @@ jobs:
       timeout-minutes: 3
 
   check-clearly-defined:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4.2.2
       timeout-minutes: 2

--- a/build-webCI.yaml
+++ b/build-webCI.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2022-secure'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-20.04'
+    linuxImage: 'ubuntu-latest'
     Codeql.Enabled: true
 
 extends:

--- a/build-webCI.yaml
+++ b/build-webCI.yaml
@@ -13,7 +13,7 @@ trigger:
 
 variables:
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-11'
+    macImage: 'macOS-latest'
     linuxImage: 'ubuntu-latest'
     Codeql.Enabled: true
 

--- a/build-webCI.yaml
+++ b/build-webCI.yaml
@@ -13,8 +13,8 @@ trigger:
 
 variables:
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-latest'
-    linuxImage: 'ubuntu-latest'
+    macImage: 'macOS-14'
+    linuxImage: 'ubuntu-22.04'
     Codeql.Enabled: true
 
 extends:

--- a/build.yaml
+++ b/build.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2022-secure'
     macImage: 'macOS-11'
-    linuxImage: 'ubuntu-20.04'
+    linuxImage: 'ubuntu-latest'
     Codeql.Enabled: true
 
 extends:

--- a/build.yaml
+++ b/build.yaml
@@ -13,7 +13,7 @@ trigger:
 
 variables:
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-11'
+    macImage: 'macOS-latest'
     linuxImage: 'ubuntu-latest'
     Codeql.Enabled: true
 

--- a/build.yaml
+++ b/build.yaml
@@ -13,8 +13,8 @@ trigger:
 
 variables:
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-latest'
-    linuxImage: 'ubuntu-latest'
+    macImage: 'macOS-14'
+    linuxImage: 'ubuntu-22.04'
     Codeql.Enabled: true
 
 extends:

--- a/pipeline/build-all-job-per-environment.yaml
+++ b/pipeline/build-all-job-per-environment.yaml
@@ -3,7 +3,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-11'
+    macImage: 'macOS-latest'
     linuxImage: 'ubuntu-22.04-secure'
 
 jobs:

--- a/pipeline/build-all-job-per-environment.yaml
+++ b/pipeline/build-all-job-per-environment.yaml
@@ -3,7 +3,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-latest'
+    macImage: 'macOS-14'
     linuxImage: 'ubuntu-22.04-secure'
 
 jobs:

--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -4,7 +4,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-11'
+    macImage: 'macOS-latest'
     linuxImage: 'ubuntu-22.04-secure'
 
 jobs:

--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -4,7 +4,7 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2022-secure'
-    macImage: 'macOS-latest'
+    macImage: 'macOS-14'
     linuxImage: 'ubuntu-22.04-secure'
 
 jobs:


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
1. Ubuntu 20.04 LTS runner is removed on 2025-04-15 and causing failure in github action workflow. Changed the runner to ubuntu-22.04 to avoid future failures.
2. Changing macOS-11 to macOS-14 to fix build pipeline issues. https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=58431&view=results

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
CI failure is unrelated, see https://github.com/microsoft/accessibility-insights-web/issues/7323.

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
