### PR TITLE
fix: changing linux image to ubuntu-22.04-secure

### DIFF
--- a/build-webCI.yaml
+++ b/build-webCI.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2022-secure'
     macImage: 'macOS-14'
-    linuxImage: 'ubuntu-22.04'
+    linuxImage: 'ubuntu-22.04-secure'
     Codeql.Enabled: true
 
 extends:

--- a/build.yaml
+++ b/build.yaml
@@ -14,7 +14,7 @@ trigger:
 variables:
     windowsImage: 'windows-2022-secure'
     macImage: 'macOS-14'
-    linuxImage: 'ubuntu-22.04'
+    linuxImage: 'ubuntu-22.04-secure'
     Codeql.Enabled: true
 
 extends:


### PR DESCRIPTION
#### Details

<!-- Usually a sentence or two describing what the PR changes -->
Pipeline [accessibility-insights-web CI](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=58627&view=results) is failing for ubuntu image, changed to ubuntu-22.04-secure to resolve the issue.

Passing [pipeline run](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=58638&view=results)

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
