### PR TITLE
fix: suppress fluent ui tabster false positive

### DIFF
--- a/src/scanner/result-decorator.ts
+++ b/src/scanner/result-decorator.ts
@@ -38,6 +38,7 @@ export class ResultDecorator {
     private decorateAxeRuleResults(
         ruleResults: AxeRule[],
         isInapplicable: boolean = false,
+        isViolation: boolean = false,
     ): RuleResult[] {
         return ruleResults.reduce((filteredArray: RuleResult[], result: AxeRule) => {
             this.messageDecorator.decorateResultWithMessages(result);
@@ -47,7 +48,9 @@ export class ResultDecorator {
             );
 
             if (processedResult != null) {
-                processedResult = this.ruleProcessor.excludeNodesByCustomLogic(processedResult);
+                if (!isViolation) {
+                    processedResult = this.ruleProcessor.suppressFluentUITabsterResult(processedResult);
+                }
             }
             if (processedResult != null) {
                 filteredArray.push({

--- a/src/scanner/result-decorator.ts
+++ b/src/scanner/result-decorator.ts
@@ -23,7 +23,7 @@ export class ResultDecorator {
     public decorateResults(results: Axe.AxeResults): ScanResults {
         const scanResults: ScanResults = {
             passes: this.decorateAxeRuleResults(results.passes),
-            violations: this.decorateAxeRuleResults(results.violations),
+            violations: this.decorateAxeRuleResults(results.violations, false, true),
             inapplicable: this.decorateAxeRuleResults(results.inapplicable, true),
             incomplete: this.decorateAxeRuleResults(results.incomplete),
             timestamp: results.timestamp,
@@ -48,8 +48,9 @@ export class ResultDecorator {
             );
 
             if (processedResult != null) {
-                if (!isViolation) {
-                    processedResult = this.ruleProcessor.suppressFluentUITabsterResult(processedResult);
+                if (isViolation) {
+                    processedResult =
+                        this.ruleProcessor.suppressFluentUITabsterResult(processedResult);
                 }
             }
             if (processedResult != null) {

--- a/src/scanner/result-decorator.ts
+++ b/src/scanner/result-decorator.ts
@@ -41,11 +41,14 @@ export class ResultDecorator {
     ): RuleResult[] {
         return ruleResults.reduce((filteredArray: RuleResult[], result: AxeRule) => {
             this.messageDecorator.decorateResultWithMessages(result);
-            const processedResult = this.ruleProcessor.suppressChecksByMessages(
+            let processedResult = this.ruleProcessor.suppressChecksByMessages(
                 result,
                 !isInapplicable,
             );
 
+            if (processedResult != null) {
+                processedResult = this.ruleProcessor.excludeNodesByCustomLogic(processedResult);
+            }
             if (processedResult != null) {
                 filteredArray.push({
                     ...processedResult,

--- a/src/scanner/rule-processor.ts
+++ b/src/scanner/rule-processor.ts
@@ -29,7 +29,7 @@ export class RuleProcessor {
 
     public suppressFluentUITabsterResult(result: AxeRule): AxeRule {
         /**
-         * [False Positive] aria-hidden-focus on elements with data-tabster-dummy #2769
+         * [False Positive] aria-hidden-focus on elements with data-tabster-dummy #7598
          * Resolves a known issue with Fluent UI, which uses Tabster to manage focus.
          * Tabster inserts hidden but focusable elements into the DOM, which can trigger
          * false positives for the 'aria-hidden-focus' rule in WCP accessibility scans.
@@ -37,7 +37,10 @@ export class RuleProcessor {
 
         if (result.id === 'aria-hidden-focus') {
             result.nodes = result.nodes.filter(node => {
-                return !node.html.includes('data-tabster-dummy');
+                return !(
+                    node.html.includes('data-tabster-dummy') ||
+                    node.html.includes('data-is-focus-trap-zone-bumper="true"')
+                );
             });
         }
         return result;

--- a/src/scanner/rule-processor.ts
+++ b/src/scanner/rule-processor.ts
@@ -27,20 +27,22 @@ export class RuleProcessor {
         return rule;
     }
 
-    public excludeNodesByCustomLogic(rule: AxeRule): AxeRule | null {
-        rule.nodes = rule.nodes.filter((nodeResult: AxeNodeResult) => {
-            return !(
-                rule.id === 'aria-hidden-focus' &&
-                nodeResult.html.toLowerCase().includes('data-tabster-dummy')
-            );
-        });
+    public suppressFluentUITabsterResult(result: AxeRule): AxeRule {
+        /**
+         * [False Positive] aria-hidden-focus on elements with data-tabster-dummy #2769
+         * Resolves a known issue with Fluent UI, which uses Tabster to manage focus.
+         * Tabster inserts hidden but focusable elements into the DOM, which can trigger
+         * false positives for the 'aria-hidden-focus' rule in WCP accessibility scans.
+         */
 
-        if (rule.nodes.length === 0) {
-            return null;
+        if (result.id === 'aria-hidden-focus') {
+            result.nodes = result.nodes.filter((node: AxeNodeResult) => {
+                return !node.html.includes('data-tabster-dummy');
+            });
         }
-
-        return rule;
+        return result;
     }
+
     private normalizeMessage(message: string): string {
         return message.toLowerCase().trim();
     }

--- a/src/scanner/rule-processor.ts
+++ b/src/scanner/rule-processor.ts
@@ -36,7 +36,7 @@ export class RuleProcessor {
          */
 
         if (result.id === 'aria-hidden-focus') {
-            result.nodes = result.nodes.filter((node: AxeNodeResult) => {
+            result.nodes = result.nodes.filter(node => {
                 return !node.html.includes('data-tabster-dummy');
             });
         }

--- a/src/scanner/rule-processor.ts
+++ b/src/scanner/rule-processor.ts
@@ -27,6 +27,20 @@ export class RuleProcessor {
         return rule;
     }
 
+    public excludeNodesByCustomLogic(rule: AxeRule): AxeRule | null {
+        rule.nodes = rule.nodes.filter((nodeResult: AxeNodeResult) => {
+            return !(
+                rule.id === 'aria-hidden-focus' &&
+                nodeResult.html.toLowerCase().includes('data-tabster-dummy')
+            );
+        });
+
+        if (rule.nodes.length === 0) {
+            return null;
+        }
+
+        return rule;
+    }
     private normalizeMessage(message: string): string {
         return message.toLowerCase().trim();
     }

--- a/src/tests/unit/tests/scanner/result-decorator.test.ts
+++ b/src/tests/unit/tests/scanner/result-decorator.test.ts
@@ -109,11 +109,6 @@ describe('ResultDecorator', () => {
                 .returns(result => result)
                 .verifiable();
 
-            ruleProcessorMock
-                .setup(m => m.normalizedSuppressedMessages)
-                .returns(() => [])
-                .verifiable();
-
             const testSubject = new ResultDecorator(
                 documentUtilsMock.object,
                 messageDecoratorMock.object,
@@ -125,6 +120,7 @@ describe('ResultDecorator', () => {
 
             expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
 
+            ruleProcessorMock.verifyAll();
             documentUtilsMock.verifyAll();
             messageDecoratorMock.verifyAll();
             mockTagToLinkMapper.verifyAll();
@@ -226,11 +222,6 @@ describe('ResultDecorator', () => {
                 .returns(result => result)
                 .verifiable();
 
-            ruleProcessorMock
-                .setup(m => m.normalizedSuppressedMessages)
-                .returns(() => [])
-                .verifiable();
-
             const testSubject = new ResultDecorator(
                 documentUtilsMock.object,
                 messageDecoratorMock.object,
@@ -243,6 +234,7 @@ describe('ResultDecorator', () => {
             );
 
             expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
+            ruleProcessorMock.verifyAll();
             documentUtilsMock.verifyAll();
             messageDecoratorMock.verifyAll();
             tagToLinkMapperMock.verifyAll();

--- a/src/tests/unit/tests/scanner/result-decorator.test.ts
+++ b/src/tests/unit/tests/scanner/result-decorator.test.ts
@@ -104,6 +104,16 @@ describe('ResultDecorator', () => {
                 })
                 .verifiable();
 
+            ruleProcessorMock
+                .setup(m => m.suppressFluentUITabsterResult(instanceStub))
+                .returns(result => result)
+                .verifiable();
+
+            ruleProcessorMock
+                .setup(m => m.normalizedSuppressedMessages)
+                .returns(() => [])
+                .verifiable();
+
             const testSubject = new ResultDecorator(
                 documentUtilsMock.object,
                 messageDecoratorMock.object,
@@ -114,7 +124,7 @@ describe('ResultDecorator', () => {
             const decoratedResult = testSubject.decorateResults(nonEmptyResultStub);
 
             expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
-            ruleProcessorMock.verifyAll();
+
             documentUtilsMock.verifyAll();
             messageDecoratorMock.verifyAll();
             mockTagToLinkMapper.verifyAll();
@@ -211,6 +221,16 @@ describe('ResultDecorator', () => {
                 })
                 .verifiable();
 
+            ruleProcessorMock
+                .setup(m => m.suppressFluentUITabsterResult(violationInstance))
+                .returns(result => result)
+                .verifiable();
+
+            ruleProcessorMock
+                .setup(m => m.normalizedSuppressedMessages)
+                .returns(() => [])
+                .verifiable();
+
             const testSubject = new ResultDecorator(
                 documentUtilsMock.object,
                 messageDecoratorMock.object,
@@ -223,7 +243,6 @@ describe('ResultDecorator', () => {
             );
 
             expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
-            ruleProcessorMock.verifyAll();
             documentUtilsMock.verifyAll();
             messageDecoratorMock.verifyAll();
             tagToLinkMapperMock.verifyAll();

--- a/src/tests/unit/tests/scanner/rule-processor.test.ts
+++ b/src/tests/unit/tests/scanner/rule-processor.test.ts
@@ -191,4 +191,37 @@ describe('RuleProcessor', () => {
         const actual = testSubject.suppressChecksByMessages(initialAxeRule);
         expect(actual).toBeNull();
     });
+
+    it('suppressFluentUITabsterResult: removes only Tabster dummy nodes and retains valid errors', () => {
+        const falsePositiveNode: AxeNodeResult = {
+            any: [],
+            none: [],
+            all: [],
+            html: '<i tabindex="0" data-tabster-dummy="" aria-hidden="true">hello1</i>',
+            target: ['#falsePositive'],
+        };
+
+        const trueErrorNode: AxeNodeResult = {
+            any: [],
+            none: [],
+            all: [],
+            html: '<i tabindex="0" aria-hidden="true">hello2</i>',
+            target: ['#trueError'],
+        };
+
+        const initialAxeRule: AxeRule = {
+            id: 'aria-hidden-focus',
+            nodes: [falsePositiveNode, trueErrorNode],
+            description: 'aria hidden focus issue',
+        };
+
+        const expectedAxeRule: AxeRule = {
+            id: 'aria-hidden-focus',
+            nodes: [trueErrorNode],
+            description: 'aria hidden focus issue',
+        };
+
+        const actual = testSubject.suppressFluentUITabsterResult(initialAxeRule);
+        expect(actual).toEqual(expectedAxeRule);
+    });
 });


### PR DESCRIPTION
#### Details

This PR adds the function to identity fluent ui false positive for aria-hidden-focus. It exclude the violation result for html containing `data-tabster-dummy` for aria-hidden-focus rule.

##### Motivation

addresses issue #7598 

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #7598 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
