### PR TITLE
fix(needs-review): handle null payload in visual helper toggle

### DIFF
--- a/src/background/actions/needs-review-card-selection-action-creator.ts
+++ b/src/background/actions/needs-review-card-selection-action-creator.ts
@@ -72,14 +72,16 @@ export class NeedsReviewCardSelectionActionCreator {
         );
     };
 
-    private onToggleVisualHelper = async (payload: VisualizationTogglePayload): Promise<void> => {
+    private onToggleVisualHelper = async (payload: VisualizationTogglePayload | null): Promise<void> => {
         await this.needsReviewCardSelectionActions.toggleVisualHelper.invoke(null);
-        if (payload.enabled) {
-            await this.visualizationActions.disableVisualization.invoke(payload.test);
-        } else {
-            await this.visualizationActions.enableVisualization.invoke(payload);
+        if (payload && payload.enabled !== undefined && payload.test !== undefined) {
+            if (payload.enabled) {
+                await this.visualizationActions.disableVisualization.invoke(payload.test);
+            } else {
+                await this.visualizationActions.enableVisualization.invoke(payload);
+            }
+            this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
         }
-        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
     };
 
     private onCollapseAllRules = async (payload: BaseActionPayload): Promise<void> => {

--- a/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/needs-review-card-selection-action-creator.test.ts
@@ -14,7 +14,7 @@ import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
 import { VisualizationType } from 'common/types/visualization-type';
 import { MockInterpreter } from 'tests/unit/tests/background/global-action-creators/mock-interpreter';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 import { createAsyncActionMock } from '../global-action-creators/action-creator-test-helpers';
 
@@ -139,6 +139,37 @@ describe('NeedsReviewCardSelectionActionCreator', () => {
             tabId,
         );
         visualizationActionsMock.verify(actions => actions['disableVisualization'], Times.once());
+    });
+
+    test('onToggleVisualHelper with null payload only toggles visual helper', async () => {
+        const toggleVisualHelperMock = createAsyncActionMock(null);
+        const actionsMock = createNeedsReviewActionsMock(
+            'toggleVisualHelper',
+            toggleVisualHelperMock.object,
+        );
+
+        const testSubject = new NeedsReviewCardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            visualizationActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        await interpreterMock.simulateMessage(
+            Messages.NeedsReviewCardSelection.ToggleVisualHelper,
+            null,
+            tabId,
+        );
+
+        toggleVisualHelperMock.verifyAll();
+        visualizationActionsMock.verify(actions => actions['enableVisualization'], Times.never());
+        visualizationActionsMock.verify(actions => actions['disableVisualization'], Times.never());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(It.isAny(), It.isAny()),
+            Times.never(),
+        );
     });
 
     test('onCollapseAllRules', async () => {


### PR DESCRIPTION
## Description

Fixes #6253 - Can't toggle off from the ad-hoc panel if you've toggled on in DetailsView

## Changes

- Updated `onToggleVisualHelper` in `needs-review-card-selection-action-creator.ts` to accept `null` payloads
- When payload is `null` (called from `action-creator.ts`), only toggle visual helper state without trying to enable/disable visualization
- Added test case to verify null payload handling

## Testing

- Added unit test to verify that when `toggleVisualHelper` is called with `null`, it only toggles the visual helper state and doesn't try to enable/disable the visualization
- Existing tests continue to pass

## Root Cause

When toggling the Needs Review visualization ON in DetailsView, `action-creator.ts` calls `toggleVisualHelper.invoke(null)` to sync the visual helper state. However, `onToggleVisualHelper` was trying to access `payload.enabled` which doesn't exist when payload is `null`, causing the toggle to get stuck in the ad-hoc panel.