### PR TITLE
chore: Bump accessibility-insights-report to v7.5.0 and accessibility-insights-ui to v2.2.0

### DIFF
--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "7.4.0",
+    "version": "7.5.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "files": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-ui",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "Accessibility Insights UI Components",
     "license": "MIT",
     "files": [


### PR DESCRIPTION
#### Details

Bumps the package versions for `accessibility-insights-report` (`7.4.0` → `7.5.0`) and `accessibility-insights-ui` (`2.1.0` → `2.2.0`) to publish the latest changes to npm.

##### Motivation

The previous PR (#7741) required to bump the version 

##### Context

- This is a version bump only — no code changes.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS