### PR TITLE
chore(deps): Bump picomatch from 2.3.1 to 2.3.2 in /deploy

### DIFF
--- a/deploy/yarn.lock
+++ b/deploy/yarn.lock
@@ -799,9 +799,9 @@ path-root@^0.1.1:
     path-root-regex "^0.1.0"
 
 picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pretty-bytes@^5.4.1:
   version "5.6.0"


### PR DESCRIPTION
#### Details

Bumps [picomatch](https://github.com/micromatch/picomatch) from 2.3.1 to 2.3.2.

Manual PR for dependabot [#7735](https://github.com/microsoft/accessibility-insights-web/pull/7735), as that was failing at check-clearly-defined step but details for this package is present [here](https://api.clearlydefined.io/definitions/npm/npmjs/-/picomatch/2.3.2)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
