### PR TITLE
Bump report and UI package versions

### DIFF
--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-report",
-    "version": "7.6.0",
+    "version": "7.7.0",
     "description": "Accessibility Insights Report",
     "license": "MIT",
     "files": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "accessibility-insights-ui",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "Accessibility Insights UI Components",
     "license": "MIT",
     "files": [


### PR DESCRIPTION
Bumping up minor versions for `accessibility-insights-report` and `accessibility-insights-ui` packages to run release pipelines to fix S360 items.
- accessibility-insights-report: 7.6.0 -> 7.7.0
- accessibility-insights-ui: 2.3.0 -> 2.4.0

No code changes.