### PR TITLE
[s360-breeze-toolkit: SFI-ES4.2.4] Onboard pipelines to CFSClean network isolation

### DIFF
--- a/pipeline/build-package-report.yaml
+++ b/pipeline/build-package-report.yaml
@@ -14,6 +14,10 @@ resources:
 extends:
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
     parameters:
+        settings:
+            # SFI-ES4.2.4: block public package-feed access (NuGet/NPM/Yarn/PyPI/Maven/Cargo).
+            # Appended to the default Permissive policy; never set CFSClean alone.
+            networkIsolationPolicy: Permissive,CFSClean
         pool:
             os: linux
             image: ubuntu-22.04-secure

--- a/pipeline/build-package-ui.yaml
+++ b/pipeline/build-package-ui.yaml
@@ -14,6 +14,10 @@ resources:
 extends:
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
     parameters:
+        settings:
+            # SFI-ES4.2.4: block public package-feed access (NuGet/NPM/Yarn/PyPI/Maven/Cargo).
+            # Appended to the default Permissive policy; never set CFSClean alone.
+            networkIsolationPolicy: Permissive,CFSClean
         pool:
             os: linux
             image: ubuntu-22.04-secure

--- a/pipeline/build-shared.yaml
+++ b/pipeline/build-shared.yaml
@@ -21,6 +21,11 @@ extends:
     ${{ else }}:
         template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
     parameters:
+        settings:
+            # SFI-ES4.2.4: block public package-feed access (NuGet/NPM/Yarn/PyPI/Maven/Cargo).
+            # Applies to both build.yaml and build-webCI.yaml (Accessibility Insights Web CI).
+            # Appended to the default Permissive policy; never set CFSClean alone.
+            networkIsolationPolicy: Permissive,CFSClean
         pool:
             name: $(a11yInsightsPool) # Name of your hosted pool
             image: windows-2022-secure # Name of the image in your pool. If not specified, first image of the pool is used

--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -35,6 +35,9 @@ extends:
             os: windows
         settings:
             skipBuildTagsForGitHubPullRequests: true
+            # SFI-ES4.2.4: block public package-feed access (NuGet/NPM/Yarn/PyPI/Maven/Cargo).
+            # Appended to the default Permissive policy; never set CFSClean alone.
+            networkIsolationPolicy: Permissive,CFSClean
         sdl:
             codeql:
                 compiled:


### PR DESCRIPTION
## SFI-ES4.2.4 — Central Feed Services (CFS) network isolation onboarding

Appends `CFSClean` to the `networkIsolationPolicy` of the four 1ES pipelines flagged by
S360 action item **[SFI-ES4.2.4] Network Isolation for CFS endpoints** so their runs stop
reaching public package feeds (NuGet/NPM/Yarn/PyPI/Maven/Cargo). This is the same change
S360 Breeze auto-fix applies.

### Pipelines remediated (source YAML lives in this repo)

| S360 item | Pipeline | ADO org | Def | YAML edited |
|-----------|----------|---------|-----|-------------|
| Use CFS package feeds for pipeline: publish accessibility-insights-ui to npm | publish accessibility-insights-ui to npm | accessibility-insights-private | 53 | `pipeline/build-package-ui.yaml` |
| Use CFS package feeds for pipeline: publish accessibility-insights-report to npm | publish accessibility-insights-report to npm | accessibility-insights-private | 43 | `pipeline/build-package-report.yaml` |
| Use CFS package feeds for pipeline: web-e2e-reliability | web-e2e-reliability | accessibility-insights | 40 | `pipeline/e2e-reliability.yaml` |
| Use CFS package feeds for pipeline: Accessibility Insights Web CI | Accessibility Insights Web CI | mseng | 17304 | `build-webCI.yaml` → shared `pipeline/build-shared.yaml` |

> The mseng CI (17304) and the `accessibility-insights` `build.yaml` CI both extend
> `pipeline/build-shared.yaml`, so the policy is applied once in the shared template and
> covers both.

The policy is always **appended** to the existing `Permissive` policy — never set to
`CFSClean` alone (which would block all network access).

### ⚠️ Validation note — this repo currently uses the public registry
`.yarnrc.yml` sets no `npmRegistryServer` and there is no `.npmrc`, so `yarn install --immutable`
resolves from the public Yarn/NPM registry today. `CFSClean` blocks those endpoints. Before
merging, please confirm via a pipeline run that package restore still succeeds. If `yarn install`
fails under `CFSClean`, the repo needs an Azure Artifacts / CFS-mirrored feed configured in
`.yarnrc.yml` (plus `npmAuthenticate`) — happy to help wire that up once you share the feed
org/project/name.

### Validation checklist (per pipeline, after the next run)
1. In the build logs, expand the **"Stop Network Isolation"** task.
2. Confirm none of the previously-flagged public feed endpoints appear under **Audited Connections**.
3. If clean, run 2 more times within 7 days — after the 3rd clean run the S360 item auto-resolves.
4. If violations persist, they are typically involuntary metadata requests that `CFSClean` correctly blocks; paste the new Audited Connections list if a *new* endpoint appears.

### Out of scope (different repo)
Five sibling ES-4.2.4 items target `microsoft/axe-pipelines-samples` (pipelines 25/32/33/42/43
in the `accessibility-insights` org), whose YAML is **not** in this repo. They must be
remediated in that repository.

TSG: https://aka.ms/1es/netiso/CFS

---
🛠️ s360-breeze-toolkit · SFI-ES4.2.4 · run `8b763335`
<!-- s360-toolkit-attribution: {"schema":"1.1","run_id":"8b763335-7283-4686-8218-e77e93d26945","kpi_id":"SFI-ES4.2.4","program":"SFI","skill":"sfi-es424-central-feed-services","arm":"dedicated_skill","action_items":["0f27291c-bc52-49fa-a978-7b4a9c362107:2d8849b6-8f00-4d5c-ba2a-7326d39fc178"],"plugin_version":"unknown","plugin_channel":"local"} -->
