### PR TITLE
Update react-router-dom to version 7.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
         "react-dom": "^18.3.1",
         "react-helmet-async": "^2.0.5",
         "react-resize-detector": "^9.1.1",
-        "react-router-dom": "^7.18.1",
+        "react-router-dom": "^7.18.2",
         "tabbable": "^6.2.0",
         "ua-parser-js": "^1.0.37",
         "uuid": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3454,7 +3454,7 @@ __metadata:
     react-dom: ^18.3.1
     react-helmet-async: ^2.0.5
     react-resize-detector: ^9.1.1
-    react-router-dom: ^7.18.1
+    react-router-dom: ^7.18.2
     regenerator-runtime: ^0.14.1
     sass: ^1.100.0
     sass-loader: ^14.2.1
@@ -10967,21 +10967,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.18.1":
-  version: 7.18.1
-  resolution: "react-router-dom@npm:7.18.1::__archiveUrl=https%3A%2F%2Fms-feed-25.pkgs.visualstudio.com%2F1es-public%2F_packaging%2Fnpm-public%2Fnpm%2Fregistry%2Freact-router-dom%2F-%2Freact-router-dom-7.18.1.tgz"
+"react-router-dom@npm:^7.18.2":
+  version: 7.18.2
+  resolution: "react-router-dom@npm:7.18.2"
   dependencies:
-    react-router: 7.18.1
+    react-router: 7.18.2
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: af8d1a9fa477ffd2dbe20a6deba6d551a4263cff05a789cff217cc8c926a4760f251c4458238530ff9c778974275d223a90392a91c53bbc64a989a2f8ee3aaa7
+  checksum: 7e5443a1bfb84878af72ea87bd1890514008399d6098a4b578ddedb938c6c5495c40dc7d17de8eccd8b00839a12dae0d80daf09270176dbbffa3ca38a7a0cadd
   languageName: node
   linkType: hard
 
-"react-router@npm:7.18.1":
-  version: 7.18.1
-  resolution: "react-router@npm:7.18.1::__archiveUrl=https%3A%2F%2Fms-feed-25.pkgs.visualstudio.com%2F1es-public%2F_packaging%2Fnpm-public%2Fnpm%2Fregistry%2Freact-router%2F-%2Freact-router-7.18.1.tgz"
+"react-router@npm:7.18.2":
+  version: 7.18.2
+  resolution: "react-router@npm:7.18.2"
   dependencies:
     cookie: ^1.0.1
     set-cookie-parser: ^2.6.0
@@ -10991,7 +10991,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 797a6f873439d2c2a0887281b408e53ceb57ddf49aacac95a8f0db2d9b4c7d9345cf14d7716b6b91830409ac27af5f8065407ea1cf0371ec0b1041d0aef2d230
+  checksum: 945d24fd3ec7f113f384fde00463fd75b7f1cf5bf76fc2cd1f46cfc2c5610516c538ec55f9294d11a72988179949ed1b8470e4b2571d4b7031016f83c55f51cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request makes a minor dependency update. The only change is upgrading the `react-router-dom` package from version 7.18.1 to 7.18.2 in the `package.json` file.

Resolves - [4 S360 Items](https://vnext.s360.msftcloudes.com/blades/security?global=@UDGATHAD%2BUdaya%20Sheshadri%20Gathadahalli%20(UDGATHAD)&blade=KPI:928b7015-db58-41a3-94ea-ab73c7bb9f4d~SLA:3~AssignedTo:AssignedToServices~Forums:All~Program:8464174e-2437-4987-bcd5-824983726552~waves:All~Tab:Summary~_loc:Security&peopleBasedNodes=udgathad_team&tile=S360_ServiceTreeServiceName:Accessibility%20Insights%20for%20Web~_loc:__key__Security__928b7015-db58-41a3-94ea-ab73c7bb9f4d)

Also Closes the following CG Work Items - 
[582](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_workitems/edit/582)
[2448099](https://dev.azure.com/mseng/1ES/_workitems/edit/2448099)