### PR TITLE
fix: Clarify 'No missing headings' summary text

### DIFF
--- a/src/assessments/headings/test-steps/no-missing-headings.tsx
+++ b/src/assessments/headings/test-steps/no-missing-headings.tsx
@@ -15,7 +15,7 @@ import { HeadingsTestStep } from './test-steps';
 
 const missingHeadingsDescription: JSX.Element = (
     <span>
-        Text that <Markup.Emphasis>looks like</Markup.Emphasis> a heading must be{' '}
+        Text that <Markup.Emphasis>labels a section of the page</Markup.Emphasis> must be{' '}
         <Markup.Emphasis>coded</Markup.Emphasis> as a heading.
     </span>
 );
@@ -26,7 +26,7 @@ const missingHeadingsHowToTest: JSX.Element = (
         <ol>
             <li>
                 Examine the target page to verify that each element that{' '}
-                <Markup.Emphasis>looks like a</Markup.Emphasis> heading is{' '}
+                <Markup.Emphasis>labels a section of the page</Markup.Emphasis> is{' '}
                 <Markup.Emphasis>coded</Markup.Emphasis> as a heading (highlighted).
             </li>
             <ManualTestRecordYourResults isMultipleFailurePossible={true} />

--- a/src/content/test/headings/no-missing-headings.tsx
+++ b/src/content/test/headings/no-missing-headings.tsx
@@ -11,7 +11,7 @@ export const whyItMatters = create(() => (
 
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
-        <p>Text that looks like a heading must be coded as a heading.</p>
+        <p>Text that labels a section of the page must be coded as a heading.</p>
         <h2>Why it matters</h2>
         <p>
             People with good vision can quickly scan a page to identify headings based solely on their appearance, such as large or bold

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -13300,7 +13300,7 @@ exports[`Guidance Content pages test/headings/noMissingHeadings matches the snap
       class="content"
     >
       <p>
-        Text that looks like a heading must be coded as a heading.
+        Text that labels a section of the page must be coded as a heading.
       </p>
       <h2>
         Why it matters

--- a/src/tests/unit/tests/reports/__snapshots__/assessment-json-export-json-builder.test.ts.snap
+++ b/src/tests/unit/tests/reports/__snapshots__/assessment-json-export-json-builder.test.ts.snap
@@ -305,7 +305,7 @@ exports[`Assessment JSON export builder export JSON matches snapshot 1`] = `
         },
         {
           "requirementKey": "missingHeadings",
-          "requirementDescription": "Text that looks like a heading must be coded as a heading"
+          "requirementDescription": "Text that labels a section of the page must be coded as a heading"
         },
         {
           "requirementKey": "headingLevel",
@@ -732,7 +732,7 @@ exports[`Assessment JSON export builder export JSON matches snapshot 1`] = `
         },
         {
           "requirementKey": "missingHeadings",
-          "requirementDescription": "Text that looks like a heading must be coded as a heading"
+          "requirementDescription": "Text that labels a section of the page must be coded as a heading"
         },
         {
           "requirementKey": "bypassBlocks",

--- a/src/tests/unit/tests/test-resources/reports/json-export-report-model-data.json
+++ b/src/tests/unit/tests/test-resources/reports/json-export-report-model-data.json
@@ -3866,12 +3866,12 @@
                                         "key": null,
                                         "ref": null,
                                         "props": {
-                                            "children": "looks like"
+                                            "children": "labels a section of the page"
                                         },
                                         "_owner": null,
                                         "_store": {}
                                     },
-                                    " a heading must be",
+                                    " must be",
                                     " ",
                                     {
                                         "key": null,


### PR DESCRIPTION
#### Details

Clarifies the summary text for the "No missing headings" requirement (#7762). The previous wording ("Text that **looks like** a heading must be coded as a heading") can be confusing or misleading, since it can feed into the common misconception that headings should be used to format text. The new wording describes headings by their function instead of their appearance.

New wording:

> Text that **labels a section of the page** must be coded as a heading.

This change touches:

- The requirement description in the headings assessment test step
- The "How to test" instructions for the same test step
- The associated guidance content page
- Test snapshots that mirror the updated text

#### Motivation

Addresses #7762

#### Pull request checklist

- [x] Addresses an existing issue: #7762
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
